### PR TITLE
agent path fix -- canceled

### DIFF
--- a/GuestConfiguration.psd1
+++ b/GuestConfiguration.psd1
@@ -4,7 +4,7 @@
 RootModule = 'GuestConfiguration.psm1'
 
 # Version number of this module.
-moduleVersion = '1.19.1'
+moduleVersion = '1.19.2'
 
 # ID used to uniquely identify this module
 GUID = '164465d5-6575-4e7f-b80b-680e4198354e'

--- a/GuestConfiguration.psm1
+++ b/GuestConfiguration.psm1
@@ -1,8 +1,10 @@
 Set-StrictMode -Version latest
 $ErrorActionPreference = 'Stop'
+$DefaultReleaseVersion = '0.0.0'
 
 Import-Module $PSScriptRoot/helpers/DscOperations.psm1 -Force
 Import-Module $PSScriptRoot/helpers/GuestConfigurationPolicy.psm1 -Force
+Import-LocalizedData -BaseDirectory $PSScriptRoot -FileName GuestConfiguration.psd1 -BindingVariable GuestConfigurationManifest
 
 $currentCulture = [System.Globalization.CultureInfo]::CurrentCulture
 if(($currentCulture.Name -eq 'en-US-POSIX') -and ($(Get-OSPlatform) -eq 'Linux')) {
@@ -169,6 +171,12 @@ function Test-GuestConfigurationPackage
         }
 
         # Unzip Guest Configuration binaries
+        try {
+            $Version = $GuestConfigurationManifest.moduleVersion
+        } catch {
+            $Version = $DefaultReleaseVersion
+        }
+        Initialize-Path $Version
         $gcBinPath = Get-GuestConfigBinaryPath
         if(-not (Test-Path $gcBinPath)) {
             $zippedBinaryPath = Join-Path $(Get-GuestConfigurationModulePath) 'bin'

--- a/helpers/GuestConfigPath.psm1
+++ b/helpers/GuestConfigPath.psm1
@@ -1,5 +1,17 @@
 Set-StrictMode -Version latest
 $ErrorActionPreference = 'Stop'
+$ReleaseVersion
+
+function Initialize-Path
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$true, Position=0)]
+        [string] $Version
+    )
+
+    $global:ReleaseVersion = $Version
+}
 
 function Get-GuestConfigurationModulePath
 {
@@ -22,7 +34,7 @@ function Get-GuestConfigBinaryPath
     [CmdletBinding()]
     param()
 
-    return Join-path (Join-path $(Get-GuestConfigPath) 'bin') 'DSC'
+    return Join-path (Join-path (Join-path $(Get-GuestConfigPath) 'bin') $ReleaseVersion) 'GC'
 }
 
 function Get-GuestConfigPolicyPath


### PR DESCRIPTION
1, change agent folder structure to add versioning information as bellow.
2, The old logic: 
GuestConfiguration.psm1 checks whether there's agent binary detected in "C:\ProgramData\GuestConfig\bin\DSC" path. If the path is not empty, it will do nothing. 

The new logic: 
GuestConfiguration.psm1 checks whether the agent with expected version exists. If exists, it does nothing; otherwise (if no agent binary detected or the existing agent's version is older than what it carries) it will extract and deploy the new agent.

![CodeReview](https://user-images.githubusercontent.com/62310776/77611858-b0bc8d80-6ee3-11ea-83a3-0d2204501420.png)
3, change agent folder from "DSC" to "GC"