### PR TITLE
Change ManagementGroupName to ManagementGroupId

### DIFF
--- a/GuestConfiguration.psm1
+++ b/GuestConfiguration.psm1
@@ -589,6 +589,9 @@ function New-GuestConfigurationPolicy
     .Parameter Path
         Guest Configuration policy path.
 
+    .Parameter ManagementGroupId
+        Management Group ID
+
     .Example
         Publish-GuestConfigurationPolicy -Path ./git/custom_policy
 #>
@@ -602,7 +605,7 @@ function Publish-GuestConfigurationPolicy
         [string] $Path,
 
         [parameter(Mandatory = $false)]
-        [string] $ManagementGroupName
+        [string] $ManagementGroupId
     )
 
     $rmContext = Get-AzContext
@@ -630,8 +633,8 @@ function Publish-GuestConfigurationPolicy
             $newAzureRmPolicyDefinitionParameters['Parameter'] = ConvertTo-Json -InputObject $definitionContent.parameters -Depth 15
         }
 
-        if ($ManagementGroupName) {
-            $newAzureRmPolicyDefinitionParameters['ManagementGroupName'] = $ManagementGroupName
+        if ($ManagementGroupId) {
+            $newAzureRmPolicyDefinitionParameters['ManagementGroupId'] = $ManagementGroupId
         }
 
         Write-Verbose "Publishing '$($jsonDefinition.properties.displayName)' ..."


### PR DESCRIPTION
The `managementGroupName` parameter should be `managementGroupId` as it requires the Management Group ID instead of the name.

## Error

`New-AzPolicyDefinition : AuthorizationFailed : The client '<spnId>' with object id '<spnObjectId>' does not have authorization to perform action 'Microsoft.Authorization/policydefinitions/write' over scope '/providers/Microsoft.Management/managementGroups/<managementGroupName>/providers/Microsoft.Authorization/policydefinitions/<policyDefinitionId>' or the scope is invalid.`

According to this API reference, it requires the management group ID instead of the name: https://docs.microsoft.com/en-us/rest/api/resources/managementgroups/get