### PR TITLE
overwrites existing package

### DIFF
--- a/GuestConfiguration.psm1
+++ b/GuestConfiguration.psm1
@@ -88,12 +88,12 @@ function New-GuestConfigurationPackage {
         # Copy FilesToInclude
         if (-not [string]::IsNullOrEmpty($FilesToInclude)) {
             if (Test-Path $FilesToInclude -PathType Leaf) {
-                Copy-Item -Path $FilesToInclude -Destination $unzippedPackagePath
+                Copy-Item -Path $FilesToInclude -Destination $unzippedPackagePath -Force
             }
             else {
                 $filesToIncludeFolderName = Get-Item $FilesToInclude
                 $FilesToIncludePath = Join-Path $unzippedPackagePath $filesToIncludeFolderName.Name
-                Copy-Item -Path $FilesToInclude -Destination $FilesToIncludePath -Recurse
+                Copy-Item -Path $FilesToInclude -Destination $FilesToIncludePath -Recurse -Force
             }
         }
         

--- a/helpers/GuestConfigurationPolicy.psm1
+++ b/helpers/GuestConfigurationPolicy.psm1
@@ -116,10 +116,10 @@ function Copy-DscResources {
     catch {
         write-error 'unable to find the GuestConfiguration module either as an imported module or in $env:PSModulePath'
     }
-    Copy-Item "$($latestModule.ModuleBase)/DscResources/" "$guestConfigModulePath/DscResources/" -Recurse
-    Copy-Item "$($latestModule.ModuleBase)/helpers/" "$guestConfigModulePath/helpers/" -Recurse
-    Copy-Item "$($latestModule.ModuleBase)/GuestConfiguration.psd1" "$guestConfigModulePath/GuestConfiguration.psd1"
-    Copy-Item "$($latestModule.ModuleBase)/GuestConfiguration.psm1" "$guestConfigModulePath/GuestConfiguration.psm1"
+    Copy-Item "$($latestModule.ModuleBase)/DscResources/" "$guestConfigModulePath/DscResources/" -Recurse -Force
+    Copy-Item "$($latestModule.ModuleBase)/helpers/" "$guestConfigModulePath/helpers/" -Recurse -Force
+    Copy-Item "$($latestModule.ModuleBase)/GuestConfiguration.psd1" "$guestConfigModulePath/GuestConfiguration.psd1" -Force
+    Copy-Item "$($latestModule.ModuleBase)/GuestConfiguration.psm1" "$guestConfigModulePath/GuestConfiguration.psm1" -Force
     
     # Copies DSC resource modules
     $modulesToCopy = @{ }


### PR DESCRIPTION
**Scenario**
End user runs `New-GuestConfigurationPackage` with output to folder where previous package was generated.

**Current behavior**
An error is returned by Copy-Item that the folder/files already exist.

**New behavior**
The command overwrites the existing files without prompting.

Although overwrite has the potential for someone to lose work, this is the behavior of `New-GuestConfigurationPolicy` already. The alternative would be to implement a `-Force` parameter in the cmdlet and inherit that behavior to the 6 locations in this PR.
_FEEDBACK WELCOME_