### PR TITLE
Only Windows, Ubuntu and Debian supported

### DIFF
--- a/GuestConfiguration.psd1
+++ b/GuestConfiguration.psd1
@@ -4,6 +4,7 @@
 RootModule = 'GuestConfiguration.psm1'
 
 # Version number of this module.
+
 moduleVersion = '3.1.4'
 
 # ID used to uniquely identify this module
@@ -44,7 +45,7 @@ PrivateData = @{
 
     PSData = @{
 
-        # Prerelease = 'prerelease'
+        Prerelease = 'prerelease'
 
         # Tags applied to this module. These help with module discovery in online galleries.
         Tags = 'GuestConfiguration', 'Azure', 'DSC'

--- a/GuestConfiguration.psm1
+++ b/GuestConfiguration.psm1
@@ -174,10 +174,6 @@ function Test-GuestConfigurationPackage {
     if ($IsLinux -and $OsName -notmatch 'Ubuntu|Debian') {
         throw "Testing Azure Policy Guest Configuration packages is not supported on '$OsName'.`n Please run the command on Windows, Unbuntu or Debian."
     }
-
-    if ($env:OS -notmatch "Windows" -and $IsMacOS) {
-        Throw 'The Test-GuestConfigurationPackage cmdlet is not supported on MacOS'
-    }
     
     if (-not (Test-Path $Path -PathType Leaf)) {
         Throw 'Invalid Guest Configuration package path : $($Path)'

--- a/Tests/GuestConfigurationModule.Tests.ps1
+++ b/Tests/GuestConfigurationModule.Tests.ps1
@@ -170,7 +170,9 @@ instance of MSFT_ChefInSpecResource as $MSFT_ChefInSpecResource1ref
 {
 Name = "linux-path";
 ResourceID = "[ChefInSpecResource]Audit Linux path exists";
+
 ModuleVersion = "3.1.4";
+
 SourceInfo = "::7::1::ChefInSpecResource";
 ModuleName = "GuestConfiguration";
 ConfigurationName = "DSCConfig";

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,38 @@
 # Change Log for GuestConfiguration module
+## v3.1.3
+
+- 'FilesToInclude' parameter should copy contents to 'Modules' folder
+- New-GuestConfigurationPackage cmdlet should copy ChefInspec resource from latest GuestConfiguration module
+  
+## v3.1.2
+
+- Repair carriage return line ending in inspec install script
+
+## v3.1.1
+
+- Adds pipline input for New-GuestConfigurationPackage
+## v3.1.0
+
+- Add pipeline input support for Publish-GCPackage and New-GCPolicy
+- Publish-GCPackage returns object containing ContentURI property, in support of New-GCPolicy input from pipeline
+
+## v3.0.0
+
+- Deprecate the 'Category' parameter due to service changes for Guest Assignment automatic creation
+- Catch the Test-GuestConfigurationPackage cmdlet when attempting to run on MacOS
+
+## v2.2.0
+
+- Update to path for GC lib was not updated
+
+## v2.1.0
+
+- New cmdlet publish-guestconfigurationpackage
+
+## v2.0.0
+
+- Support for "AINE without DINE"
+- Arc for Servers parameter
 
 ## [Unreleased]
 


### PR DESCRIPTION
This PR will restrict what distro can load the module.
It will throw an error if the `GuestConfiguration` module is imported in a distro that is not Windows, Ubuntu or Debian.