### PR TITLE
Added Parameter for ExpiryDate of SAS Token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pipeline and project structure updated to match DSC Community Projects.
 - Fixed casing of default parameter in generated policy, which caused issues on manual import
 - Changed how meta config are written to different files, and read from both
- 
+- Added `$ExpiryTime` Parameter to `Publish-GuestConfigurationPackage`
+
 ## [3.2.0] - 2021-02-23
 
 ### Added

--- a/source/Public/Publish-GuestConfigurationPackage.ps1
+++ b/source/Public/Publish-GuestConfigurationPackage.ps1
@@ -53,6 +53,10 @@ function Publish-GuestConfigurationPackage
         $StorageAccountName,
 
         [Parameter()]
+        [System.DateTime]
+        $ExpiryTime = (Get-Date).AddYears('3'),
+
+        [Parameter()]
         [System.String]
         $StorageContainerName = 'guestconfiguration',
 
@@ -84,7 +88,6 @@ function Publish-GuestConfigurationPackage
     $null = Set-AzStorageBlobContent @setAzStorageBlobContentParams
 
     # Get url with SAS token
-    # THREE YEAR EXPIRATION
     $StartTime = Get-Date
 
     $newAzStorageBlobSASTokenParams = @{
@@ -92,7 +95,7 @@ function Publish-GuestConfigurationPackage
         Container  = $StorageContainerName
         Blob       = $BlobName
         StartTime  = $StartTime
-        ExpiryTime = $StartTime.AddYears('3')
+        ExpiryTime = $ExpiryTime
         Permission = 'rl'
         FullUri    = $true
     }


### PR DESCRIPTION
As discussed in #182 I've added another optional Parameter which allows to set the expiration of the SAS Token to a custom date. Default still set's it to Get-Date.AddYears('3').

Tested executing existing commands, without parameter and setting the new date with different time-frame.