### PR TITLE
Release version 4.0.0-preview0010

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.0.0-preview0009]
+## [4.0.0-preview0010] - 2022-06-07
+
+### Fixed
+
+- The cmdlets Get-GuestConfigurationPackageComplianceStatus and Start-GuestConfigurationPackageRemediation will now only search for nested module dependencies in the package Modules folder
+
+## [4.0.0-preview0009] - 2022-05-27
 
 ### Changed
 

--- a/source/GuestConfiguration.psd1
+++ b/source/GuestConfiguration.psd1
@@ -41,7 +41,7 @@
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
     PrivateData = @{
         PSData = @{
-            Prerelease = 'preview0009'
+            Prerelease = 'preview0010'
 
             # Tags applied to this module. These help with module discovery in online galleries.
             Tags = @('GuestConfiguration', 'Azure', 'DSC')

--- a/source/Private/Get-ModuleDependencies.ps1
+++ b/source/Private/Get-ModuleDependencies.ps1
@@ -84,6 +84,7 @@ function Get-ModuleDependencies
             $getModuleDependenciesParameters = @{
                 ModuleName = $requiredModule.Name
                 ModuleVersion = $requiredModule.Version
+                ModuleSourcePath = $ModuleSourcePath
             }
 
             $moduleDependencies += Get-ModuleDependencies @getModuleDependenciesParameters
@@ -99,6 +100,7 @@ function Get-ModuleDependencies
 
             $getModuleDependenciesParameters = @{
                 ModuleName = $requiredModule.Name
+                ModuleSourcePath = $ModuleSourcePath
             }
 
             $moduleDependencies += Get-ModuleDependencies @getModuleDependenciesParameters


### PR DESCRIPTION
### Fixed

- The cmdlets Get-GuestConfigurationPackageComplianceStatus and Start-GuestConfigurationPackageRemediation will now only search for nested module dependencies in the package Modules folder