### PR TITLE
Release version 4.0.0-preview0011

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0-preview0011] - 2022-06-09
+
+### Fixed
+
+- The cmdlet New-GuestConfigurationPackage will never include the GuestConfiguration module in the Modules folder of the new package (this makes the package too big). A warning will be written instead.
+- The cmdlets New-GuestConfigurationPackage and Protect-GuestConfigurationPackage now use a different compression method which allows empty folders to be zipped into the package (previously empty folders were disappearing when the package was zipped).
+
 ## [4.0.0-preview0010] - 2022-06-07
 
 ### Fixed

--- a/source/GuestConfiguration.psd1
+++ b/source/GuestConfiguration.psd1
@@ -41,7 +41,7 @@
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
     PrivateData = @{
         PSData = @{
-            Prerelease = 'preview0010'
+            Prerelease = 'preview0011'
 
             # Tags applied to this module. These help with module discovery in online galleries.
             Tags = @('GuestConfiguration', 'Azure', 'DSC')

--- a/source/Private/Get-ModuleDependencies.ps1
+++ b/source/Private/Get-ModuleDependencies.ps1
@@ -24,6 +24,12 @@ function Get-ModuleDependencies
         throw "Found a dependency on resources from the PSDesiredStateConfiguration module, but we cannot copy these resources into the Guest Configuration package. Please switch these resources to using the PSDscResources module instead."
     }
 
+    if ($ModuleName -ieq 'GuestConfiguration')
+    {
+        Write-Warning -Message "Found a dependency on resources from the GuestConfiguartion module. This module does not contain any valid DSC resources, and it is too large to include in the Guest Configuration package. If you are using the native InSpec resource, you can ignore this message. If you wish to include custom native resources in the package, please copy the compiled files into the Modules/DscNativeResources/<resource_name> folder in the package manually."
+        return
+    }
+
     $getModuleParameters = @{
         ListAvailable = $true
     }

--- a/source/Public/New-GuestConfigurationPackage.ps1
+++ b/source/Public/New-GuestConfigurationPackage.ps1
@@ -414,9 +414,9 @@ function New-GuestConfigurationPackage
     }
 
     # Zip the package
-    $compressArchiveSourcePath = Join-Path -Path $packageRootPath -ChildPath '*'
-    Write-Verbose -Message "Compressing the generated package from the path '$compressArchiveSourcePath' to the package path '$packageDestinationPath'..."
-    $null = Compress-Archive -Path $compressArchiveSourcePath -DestinationPath $packageDestinationPath -CompressionLevel 'Fastest'
+    # NOTE: We are NOT using Compress-Archive here because it does not zip empty folders (like an empty Modules folder) into the package
+    Write-Verbose -Message "Compressing the generated package from the path '$packageRootPath' to the package path '$packageDestinationPath'..."
+    $null = [System.IO.Compression.ZipFile]::CreateFromDirectory($packageRootPath, $packageDestinationPath)
 
     return [PSCustomObject]@{
         PSTypeName = 'GuestConfiguration.Package'

--- a/source/Public/Protect-GuestConfigurationPackage.ps1
+++ b/source/Public/Protect-GuestConfigurationPackage.ps1
@@ -214,9 +214,9 @@ function Protect-GuestConfigurationPackage
         }
 
         # Zip the signed Guest Configuration package
+        # NOTE: We are NOT using Compress-Archive here because it does not zip empty folders (like an empty Modules folder) into the package
         Write-Verbose -Message "Creating the signed Guest Configuration package at '$signedPackageFilePath'"
-        $archiveSourcePath = Join-Path -Path $tempDirectory -ChildPath '*'
-        $null = Compress-Archive -Path $archiveSourcePath -DestinationPath $signedPackageFilePath
+        $null = [System.IO.Compression.ZipFile]::CreateFromDirectory($tempDirectory, $signedPackageFilePath)
 
         $result = [PSCustomObject]@{
             Name = $configurationName

--- a/tests/Public/New-GuestConfigurationPackage.Tests.ps1
+++ b/tests/Public/New-GuestConfigurationPackage.Tests.ps1
@@ -458,4 +458,64 @@ Describe 'New-GuestConfigurationPackage' {
             Test-Path -Path $expectedResourceModulePath -PathType 'Container' | Should -BeTrue
         }
     }
+
+    Context 'Cross-platform package with fake GuestConfiguration native resource' {
+        BeforeAll {
+            $newGuestConfigurationPackageParameters = @{
+                Name = 'testNative'
+                Configuration = Join-Path -Path $script:testMofsFolderPath -ChildPath 'GuestConfigurationResource.mof'
+                Path = Join-Path -Path $script:testOutputPath -ChildPath 'Native'
+                Verbose = $true
+            }
+
+            $compressedPackageName = "$($newGuestConfigurationPackageParameters.Name).zip"
+            $compressedPackagePath = Join-Path -Path $newGuestConfigurationPackageParameters.Path -ChildPath $compressedPackageName
+
+            $expandedPackageName = "$($newGuestConfigurationPackageParameters.Name)-Expanded"
+            $expandedPackagePath = Join-Path -Path $script:testOutputPath -ChildPath $expandedPackageName
+
+            $expandedPackageModulesPath = Join-Path -Path $expandedPackagePath -ChildPath 'Modules'
+        }
+
+        It 'Should be able to create a custom package with the expected output object' {
+            $package = New-GuestConfigurationPackage @newGuestConfigurationPackageParameters
+            $package | Should -Not -BeNull
+            $package.Name | Should -Be $newGuestConfigurationPackageParameters.Name
+            $package.Path | Should -Be $compressedPackagePath
+        }
+
+        It 'Compressed package should exist at expected output path' {
+            Test-Path -Path $compressedPackagePath -PathType 'Leaf' | Should -BeTrue
+        }
+
+        It 'Should be able to expand the new package' {
+            $null = Expand-Archive -Path $compressedPackagePath -DestinationPath $expandedPackagePath -Force
+            Test-Path -Path $expandedPackagePath -PathType 'Container' | Should -BeTrue
+        }
+
+        It 'Mof file should exist in expanded package' {
+            $expectedMofName = "$($newGuestConfigurationPackageParameters.Name).mof"
+            $expandedPackageMofFilePath = Join-Path -Path $expandedPackagePath -ChildPath $expectedMofName
+            Test-Path -Path $expandedPackageMofFilePath -PathType 'Leaf' | Should -BeTrue
+        }
+
+        It 'Metaconfig should exist with default Type (Audit) and Version (1.0.0) in expanded package' {
+            $expectedMetaconfigName = "$($newGuestConfigurationPackageParameters.Name).metaconfig.json"
+            $expectedMetaconfigPath = Join-Path -Path $expandedPackagePath -ChildPath $expectedMetaconfigName
+            Test-Path -Path $expectedMetaconfigPath -PathType 'Leaf' | Should -BeTrue
+
+            $metaconfigContent = Get-Content -Path $expectedMetaconfigPath -Raw
+            $metaconfigJson = $metaconfigContent | ConvertFrom-Json
+
+            $metaconfigJson | Should -Not -BeNullOrEmpty
+            $metaconfigJson.Type | Should -Be 'Audit'
+            $metaconfigJson.Version | Should -Be '1.0.0'
+        }
+
+        It 'Expanded package should have an empty Modules folder' {
+            Test-Path -Path $expandedPackageModulesPath -PathType 'Container' | Should -BeTrue
+            $resourceDependencies = @( Get-ChildItem -Path $expandedPackageModulesPath )
+            $resourceDependencies.Count | Should -Be 0
+        }
+    }
 }

--- a/tests/assets/TestMofs/GuestConfigurationResource.mof
+++ b/tests/assets/TestMofs/GuestConfigurationResource.mof
@@ -1,0 +1,20 @@
+instance of NativeResource as $MyNativeResourceref
+{
+    ModuleName = "GuestConfiguration";
+    ResourceID = "[NativeResource]MyNativeResource";
+    SourceInfo = "::7::9::NativeResource";
+    ModuleVersion = "2.5.0";
+    ConfigurationName = "NativeResourceConfig";
+    Name = "MyName";
+    Ensure = "Present";
+    SourcePath = "NotARealSourcePath";
+    LogPath = "NotARealLogPath";
+};
+
+instance of OMI_ConfigurationDocument
+{
+    Version="1.0.0";
+    MinimumCompatibleVersion = "1.0.0";
+    CompatibleVersionAdditionalProperties= {"Omi_BaseResource:ConfigurationName"};
+    Name="NativeResourceConfig";
+};


### PR DESCRIPTION
### Fixed

- The cmdlet New-GuestConfigurationPackage will never include the GuestConfiguration module in the Modules folder of the new package (this makes the package too big). A warning will be written instead.
- The cmdlets New-GuestConfigurationPackage and Protect-GuestConfigurationPackage now use a different compression method which allows empty folders to be zipped into the package (previously empty folders were disappearing when the package was zipped).