### PR TITLE
Release version 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0] - 2022-06-13
+
+## Added
+
+- The cmdlets Get-GuestConfigurationPackageComplianceStatus and Start-GuestConfigurationPackageRemediation will now throw an error when the Modules folder in the package does not contain any subfolders.
+
+## Changed
+
+- Moved the module out of preview
+- In New-GuestConfigurationPackage, added more messaging to the warning message when a mof contains the GuestConfiguration module.
+
 ## [4.0.0-preview0011] - 2022-06-09
 
 ### Fixed

--- a/source/GuestConfiguration.psd1
+++ b/source/GuestConfiguration.psd1
@@ -18,7 +18,7 @@
     Copyright = '(c) 2022 Microsoft Corporation. All rights reserved.'
 
     # Description of the functionality provided by this module
-    Description = '[PREVIEW] The Guest Configuration module is an experimental tool to assist in content authoring for Azure Guest Configuration. These cmdlets build and validate content packages and custom policies, which can then be used in cross-platform configuration management solutions.'
+    Description = 'The Guest Configuration module is a tool to author custom content for Azure Guest Configuration. These cmdlets build and validate content packages and custom policies, which can then be used in cross-platform configuration management solutions.'
 
     # Minimum version of the Windows PowerShell engine required by this module
     PowerShellVersion = '5.1'
@@ -41,7 +41,7 @@
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
     PrivateData = @{
         PSData = @{
-            Prerelease = 'preview0011'
+            #Prerelease = ''
 
             # Tags applied to this module. These help with module discovery in online galleries.
             Tags = @('GuestConfiguration', 'Azure', 'DSC')

--- a/source/Private/Get-ModuleDependencies.ps1
+++ b/source/Private/Get-ModuleDependencies.ps1
@@ -26,7 +26,7 @@ function Get-ModuleDependencies
 
     if ($ModuleName -ieq 'GuestConfiguration')
     {
-        Write-Warning -Message "Found a dependency on resources from the GuestConfiguartion module. This module does not contain any valid DSC resources, and it is too large to include in the Guest Configuration package. If you are using the native InSpec resource, you can ignore this message. If you wish to include custom native resources in the package, please copy the compiled files into the Modules/DscNativeResources/<resource_name> folder in the package manually."
+        Write-Warning -Message "Found a dependency on resources from the GuestConfiguartion module. This module will not be copied into the package as it does not contain any valid DSC resources and it is too large. If you wish to include custom native resources in the package, please copy the compiled files into the 'Modules/DscNativeResources/<resource_name>/' folder in the package manually. Example: <package_root>/Modules/DscNativeResources/MyNativeResource/libMyNativeResource.so AND <package_root>/Modules/DscNativeResources/MyNativeResource/MyNativeResource.schema.mof"
         return
     }
 

--- a/source/Private/Invoke-GuestConfigurationPackage.ps1
+++ b/source/Private/Invoke-GuestConfigurationPackage.ps1
@@ -157,6 +157,12 @@ function Invoke-GuestConfigurationPackage
 
     $modulesFolderPath = Join-Path -Path $packageInstallPath -ChildPath 'Modules'
 
+    $modulesFolders = @( Get-ChildItem -Path $modulesFolderPath -Directory )
+    if ($modulesFolders.Count -eq 0)
+    {
+        throw "There are no folders under the Modules folder in the package at '$modulesFolderPath'. Please use the New-GuestConfigurationPackage cmdlet to generate your package. If you wish to include custom native resources in the package, please copy the compiled files into the 'Modules/DscNativeResources/<resource_name>/' folder in the package manually. Example: <package_root>/Modules/DscNativeResources/MyNativeResource/libMyNativeResource.so AND <package_root>/Modules/DscNativeResources/MyNativeResource/MyNativeResource.schema.mof"
+    }
+
     foreach ($resourceDependency in $resourceDependencies)
     {
         if ($resourceDependency['ResourceName'] -ieq 'MSFT_ChefInSpecResource')


### PR DESCRIPTION
## Added

- The cmdlets Get-GuestConfigurationPackageComplianceStatus and Start-GuestConfigurationPackageRemediation will now throw an error when the Modules folder in the package does not contain any subfolders.

## Changed

- Moved the module out of preview
- In New-GuestConfigurationPackage, added more messaging to the warning message when a mof contains the GuestConfiguration module.