### PR TITLE
Allow non-string parameters

### DIFF
--- a/source/Private/New-GuestConfigurationPolicyParametersSection.ps1
+++ b/source/Private/New-GuestConfigurationPolicyParametersSection.ps1
@@ -12,8 +12,6 @@ function New-GuestConfigurationPolicyParametersSection
     $templateFileName = '2-Parameters.json'
     $parametersSection = Get-GuestConfigurationPolicySectionFromTemplate -FileName $templateFileName
 
-    $optionalFields = @('AllowedValues', 'DefaultValue')
-
     foreach ($currentParameter in $Parameter)
     {
         $parameterName = $currentParameter['Name']
@@ -25,13 +23,22 @@ function New-GuestConfigurationPolicyParametersSection
             }
         }
 
-        foreach ($optionalField in $optionalFields)
+        if ($currentParameter.Keys -contains 'DefaultValue')
         {
-            if ($currentParameter.Keys -contains $optionalField)
+            # Key is intentionally camelCase
+            $parametersSection.parameters.$parameterName['defaultValue'] = [string]$currentParameter['DefaultValue']
+        }
+
+        if ($currentParameter.Keys -contains 'AllowedValues')
+        {
+            $allowedStringValues = @()
+            foreach ($allowedValue in $currentParameter['AllowedValues'])
             {
-                $fieldName = $optionalField.Substring(0, 1).ToLower() + $optionalField.Substring(1)
-                $parametersSection.parameters.$parameterName.$fieldName = $currentParameter[$optionalField]
+                $allowedStringValues += [string]$allowedValue
             }
+
+            # Key is intentionally camelCase
+            $parametersSection.parameters.$parameterName['allowedValues'] = $allowedStringValues
         }
     }
 

--- a/source/Public/New-GuestConfigurationPolicy.ps1
+++ b/source/Public/New-GuestConfigurationPolicy.ps1
@@ -218,6 +218,8 @@ function New-GuestConfigurationPolicy
     }
 
     $requiredParameterProperties = @('Name', 'DisplayName', 'Description', 'ResourceType', 'ResourceId', 'ResourcePropertyName')
+    $defaultValueParameterProperty = 'DefaultValue'
+    $allowedValuesParameterProperty = 'AllowedValues'
 
     foreach ($parameterInfo in $Parameter)
     {
@@ -231,8 +233,38 @@ function New-GuestConfigurationPolicy
 
             if ($parameterInfo[$requiredParameterProperty] -isnot [string])
             {
-                $requiredParameterPropertyString = $requiredParameterProperties -join ', '
-                throw "The property '$requiredParameterProperty' of one of the specified parameters is not a string. All parameter property values must be strings."
+                throw "The mandatory property '$requiredParameterProperty' of one of the specified parameters is not a string. All mandatory property values of a parameter must be strings."
+            }
+        }
+
+        $parameterName = $parameterInfo['Name']
+        if ($parameterInfo.Keys -contains $defaultValueParameterProperty)
+        {
+            if ($parameterInfo[$defaultValueParameterProperty] -isnot [string] -and
+                $parameterInfo[$defaultValueParameterProperty] -isnot [boolean] -and
+                $parameterInfo[$defaultValueParameterProperty] -isnot [int] -and
+                $parameterInfo[$defaultValueParameterProperty] -isnot [double])
+            {
+                throw "The property '$defaultValueParameterProperty' of parameter '$parameterName' is not a string, boolean, integer, or double."
+            }
+        }
+
+        if ($parameterInfo.Keys -contains $allowedValuesParameterProperty)
+        {
+            if ($parameterInfo[$allowedValuesParameterProperty] -isnot [array])
+            {
+                throw "The property '$allowedValuesParameterProperty' of parameter '$parameterName' is not an array."
+            }
+
+            foreach ($allowedValue in $parameterInfo[$allowedValuesParameterProperty])
+            {
+                if ($allowedValue -isnot [string] -and
+                    $allowedValue -isnot [boolean] -and
+                    $allowedValue -isnot [int] -and
+                    $allowedValue -isnot [double])
+                {
+                    throw "One of the values in the array for property '$allowedValuesParameterProperty' of parameter '$parameterName' is not a string, boolean, integer, or double."
+                }
             }
         }
     }


### PR DESCRIPTION
Updates the module to allow users to specify non-string parameters for New-GuestConfigurationPolicy. Parameters of type string, Boolean, integer, or double are supported. The module internally converts these values to strings so the end result, the policy definition, is unchanged.

This change accompanies another change in the agent where the agent automatically converts string parameters to the type expected by the resource. The end goal of these changes is to support resources requiring non-string parameters while maintaining a good user experience. With this, the customer can specify an integer parameter if the resource expects an integer and the module + agent will handle the rest.