### PR TITLE
Adding new fields

### DIFF
--- a/source/Private/New-GuestConfigurationPolicyActionSection.ps1
+++ b/source/Private/New-GuestConfigurationPolicyActionSection.ps1
@@ -60,7 +60,7 @@ function New-GuestConfigurationPolicyActionSection
 
         if (-not [string]::IsNullOrWhiteSpace($ManagedIdentityResourceId))
         {
-            $setActionSectionParameters.ContentManagedIdentity = $ManagedIdentityResourceId
+            $setActionSectionParameters.ManagedIdentityResourceId = $ManagedIdentityResourceId
         }
 
         $actionSection = New-GuestConfigurationPolicySetActionSection @setActionSectionParameters

--- a/source/Private/New-GuestConfigurationPolicyActionSection.ps1
+++ b/source/Private/New-GuestConfigurationPolicyActionSection.ps1
@@ -39,7 +39,11 @@ function New-GuestConfigurationPolicyActionSection
 
         [Parameter()]
         [System.Boolean]
-        $IncludeVMSS = $true
+        $IncludeVMSS = $true,
+
+        [Parameter()]
+        [Switch]
+        $ExcludeArcMachines
     )
 
     if ($AssignmentType -ieq 'Audit')
@@ -94,6 +98,20 @@ function New-GuestConfigurationPolicyActionSection
                 $parameterCondition
             )
         }
+    }
+
+    if ($ExcludeArcMachines -and $actionSection.details.deployment.properties.template.resources)
+    {
+        $tempResources = @()
+        foreach ($resource in $actionSection.details.deployment.properties.template.resources)
+        {
+            if ($resource.condition -imatch "HybridCompute")
+            {
+                continue
+            }
+            $tempResources += $resource
+        }
+        $actionSection.details.deployment.properties.template.resources = $tempResources
     }
 
     return $actionSection

--- a/source/Private/New-GuestConfigurationPolicyActionSection.ps1
+++ b/source/Private/New-GuestConfigurationPolicyActionSection.ps1
@@ -21,7 +21,7 @@ function New-GuestConfigurationPolicyActionSection
 
         [Parameter()]
         [String]
-        $ContentManagedIdentity,
+        $ManagedIdentityResourceId,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
@@ -58,9 +58,9 @@ function New-GuestConfigurationPolicyActionSection
             IncludeVMSS = $IncludeVMSS
         }
 
-        if ($ContentManagedIdentity)
+        if (-not [string]::IsNullOrWhiteSpace($ManagedIdentityResourceId))
         {
-            $setActionSectionParameters.ContentManagedIdentity = $ContentManagedIdentity
+            $setActionSectionParameters.ContentManagedIdentity = $ManagedIdentityResourceId
         }
 
         $actionSection = New-GuestConfigurationPolicySetActionSection @setActionSectionParameters

--- a/source/Private/New-GuestConfigurationPolicyActionSection.ps1
+++ b/source/Private/New-GuestConfigurationPolicyActionSection.ps1
@@ -19,6 +19,10 @@ function New-GuestConfigurationPolicyActionSection
         [String]
         $ContentUri,
 
+        [Parameter()]
+        [String]
+        $ContentManagedIdentity,
+
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [String]
@@ -52,6 +56,11 @@ function New-GuestConfigurationPolicyActionSection
             AssignmentType = $AssignmentType
             Parameter = $Parameter
             IncludeVMSS = $IncludeVMSS
+        }
+
+        if ($ContentManagedIdentity)
+        {
+            $setActionSectionParameters.ContentManagedIdentity = $ContentManagedIdentity
         }
 
         $actionSection = New-GuestConfigurationPolicySetActionSection @setActionSectionParameters

--- a/source/Private/New-GuestConfigurationPolicyConditionsSection.ps1
+++ b/source/Private/New-GuestConfigurationPolicyConditionsSection.ps1
@@ -60,6 +60,8 @@ function New-GuestConfigurationPolicyConditionsSection
         }
     }
 
+    $conditionsSection.anyOf = [System.Collections.ArrayList]@($conditionsSection.anyOf)
+
     if ($ExcludeArcMachines)
     {
         foreach ($anyOf in $conditionsSection.anyOf)
@@ -68,14 +70,14 @@ function New-GuestConfigurationPolicyConditionsSection
             {
                 if ($allOf.value -eq "[parameters('IncludeArcMachines')]")
                 {
-                    # Find and remove the specified section
-                    $indexToRemove = $anyOf.allOf.IndexOf($allOf)
-                    if ($indexToRemove -ne -1)
-                    {
-                        $anyOf.RemoveAt($indexToRemove)
-                    }
+                    $indexToRemove = $conditionsSection.anyOf.IndexOf($anyOf)
                 }
             }
+        }
+
+        if ($indexToRemove -ne -1)
+        {
+            $conditionsSection.anyOf.RemoveAt($indexToRemove)
         }
     }
 

--- a/source/Private/New-GuestConfigurationPolicyConditionsSection.ps1
+++ b/source/Private/New-GuestConfigurationPolicyConditionsSection.ps1
@@ -15,7 +15,11 @@ function New-GuestConfigurationPolicyConditionsSection
 
         [Parameter()]
         [System.Boolean]
-        $IncludeVMSS = $true
+        $IncludeVMSS = $true,
+
+        [Parameter()]
+        [Switch]
+        $ExcludeArcMachines
     )
 
     $templateFileName = "3-Images-$Platform.json"
@@ -53,6 +57,25 @@ function New-GuestConfigurationPolicyConditionsSection
                 $conditionsSection,
                 $tagConditions
             )
+        }
+    }
+
+    if ($ExcludeArcMachines)
+    {
+        foreach ($anyOf in $conditionsSection.anyOf)
+        {
+            foreach ($allOf in $anyOf.allOf)
+            {
+                if ($allOf.value -eq "[parameters('IncludeArcMachines')]")
+                {
+                    # Find and remove the specified section
+                    $indexToRemove = $anyOf.allOf.IndexOf($allOf)
+                    if ($indexToRemove -ne -1)
+                    {
+                        $anyOf.RemoveAt($indexToRemove)
+                    }
+                }
+            }
         }
     }
 

--- a/source/Private/New-GuestConfigurationPolicyContent.ps1
+++ b/source/Private/New-GuestConfigurationPolicyContent.ps1
@@ -61,7 +61,11 @@ function New-GuestConfigurationPolicyContent
 
         [Parameter()]
         [System.Boolean]
-        $IncludeVMSS = $true
+        $IncludeVMSS = $true,
+
+        [Parameter()]
+        [Switch]
+        $ExcludeArcMachines
     )
 
     $metadataSectionParameters = @{
@@ -86,7 +90,7 @@ function New-GuestConfigurationPolicyContent
 
     $conditionsSection = New-GuestConfigurationPolicyConditionsSection -Platform $Platform -Tag $Tag -IncludeVMSS $IncludeVMSS
 
-    if (-not [string]::IsNullOrWhiteSpace($ManagedIdentityResourceId))
+    if ($ExcludeArcMachines)
     {
         foreach ($anyOf in $conditionsSection.anyOf)
         {
@@ -127,7 +131,7 @@ function New-GuestConfigurationPolicyContent
 
     $actionSection = New-GuestConfigurationPolicyActionSection @actionSectionParameters
 
-    if (-not [string]::IsNullOrWhiteSpace($ManagedIdentityResourceId) -and $actionSection.details.deployment.properties.template.resources)
+    if ($ExcludeArcMachines -and $actionSection.details.deployment.properties.template.resources)
     {
         $tempResources = @()
         foreach ($resource in $actionSection.details.deployment.properties.template.resources)

--- a/source/Private/New-GuestConfigurationPolicyContent.ps1
+++ b/source/Private/New-GuestConfigurationPolicyContent.ps1
@@ -30,7 +30,7 @@ function New-GuestConfigurationPolicyContent
 
         [Parameter()]
         [String]
-        $ContentManagedIdentity,
+        $ManagedIdentityResourceId,
 
         [Parameter(Mandatory = $true)]
         [String]
@@ -75,9 +75,9 @@ function New-GuestConfigurationPolicyContent
         Parameter = $Parameter
     }
 
-    if ($ContentManagedIdentity)
+    if (-not [string]::IsNullOrWhiteSpace($ManagedIdentityResourceId))
     {
-        $metadataSectionParameters.ContentManagedIdentity = $ContentManagedIdentity
+        $metadataSectionParameters.ContentManagedIdentity = $ManagedIdentityResourceId
     }
 
     $metadataSection = New-GuestConfigurationPolicyMetadataSection @metadataSectionParameters
@@ -86,7 +86,7 @@ function New-GuestConfigurationPolicyContent
 
     $conditionsSection = New-GuestConfigurationPolicyConditionsSection -Platform $Platform -Tag $Tag -IncludeVMSS $IncludeVMSS
 
-    if ($ContentManagedIdentity)
+    if (-not [string]::IsNullOrWhiteSpace($ManagedIdentityResourceId))
     {
         foreach ($anyOf in $conditionsSection.anyOf)
         {
@@ -120,14 +120,14 @@ function New-GuestConfigurationPolicyContent
         IncludeVMSS = $IncludeVMSS
     }
 
-    if ($ContentManagedIdentity)
+    if (-not [string]::IsNullOrWhiteSpace($ManagedIdentityResourceId))
     {
-        $actionSectionParameters.ContentManagedIdentity = $ContentManagedIdentity
+        $actionSectionParameters.ContentManagedIdentity = $ManagedIdentityResourceId
     }
 
     $actionSection = New-GuestConfigurationPolicyActionSection @actionSectionParameters
 
-    if ($ContentManagedIdentity -and $actionSection.details.deployment.properties.template.resources)
+    if (-not [string]::IsNullOrWhiteSpace($ManagedIdentityResourceId) -and $actionSection.details.deployment.properties.template.resources)
     {
         $tempResources = @()
         foreach ($resource in $actionSection.details.deployment.properties.template.resources)

--- a/source/Private/New-GuestConfigurationPolicyContent.ps1
+++ b/source/Private/New-GuestConfigurationPolicyContent.ps1
@@ -77,7 +77,7 @@ function New-GuestConfigurationPolicyContent
 
     if (-not [string]::IsNullOrWhiteSpace($ManagedIdentityResourceId))
     {
-        $metadataSectionParameters.ContentManagedIdentity = $ManagedIdentityResourceId
+        $metadataSectionParameters.ManagedIdentityResourceId = $ManagedIdentityResourceId
     }
 
     $metadataSection = New-GuestConfigurationPolicyMetadataSection @metadataSectionParameters
@@ -122,7 +122,7 @@ function New-GuestConfigurationPolicyContent
 
     if (-not [string]::IsNullOrWhiteSpace($ManagedIdentityResourceId))
     {
-        $actionSectionParameters.ContentManagedIdentity = $ManagedIdentityResourceId
+        $actionSectionParameters.ManagedIdentityResourceId = $ManagedIdentityResourceId
     }
 
     $actionSection = New-GuestConfigurationPolicyActionSection @actionSectionParameters

--- a/source/Private/New-GuestConfigurationPolicyMetadataSection.ps1
+++ b/source/Private/New-GuestConfigurationPolicyMetadataSection.ps1
@@ -34,7 +34,7 @@ function New-GuestConfigurationPolicyMetadataSection
 
         [Parameter()]
         [String]
-        $ContentManagedIdentity,
+        $ManagedIdentityResourceId,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
@@ -62,9 +62,9 @@ function New-GuestConfigurationPolicyMetadataSection
         contentHash = $ContentHash
     }
 
-    if ($ContentManagedIdentity)
+    if (-not [string]::IsNullOrWhiteSpace($ManagedIdentityResourceId))
     {
-        $propertiesSection.metadata.guestConfiguration.contentManagedIdentity = $ContentManagedIdentity
+        $propertiesSection.metadata.guestConfiguration.contentManagedIdentity = $ManagedIdentityResourceId
     }
 
     if ($null -ne $Parameter -and $Parameter.Count -gt 0)

--- a/source/Private/New-GuestConfigurationPolicyMetadataSection.ps1
+++ b/source/Private/New-GuestConfigurationPolicyMetadataSection.ps1
@@ -32,6 +32,10 @@ function New-GuestConfigurationPolicyMetadataSection
         [String]
         $ContentUri,
 
+        [Parameter()]
+        [String]
+        $ContentManagedIdentity,
+
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [String]
@@ -56,6 +60,11 @@ function New-GuestConfigurationPolicyMetadataSection
         contentType = 'Custom'
         contentUri = $ContentUri
         contentHash = $ContentHash
+    }
+
+    if ($ContentManagedIdentity)
+    {
+        $propertiesSection.metadata.guestConfiguration.contentManagedIdentity = $ContentManagedIdentity
     }
 
     if ($null -ne $Parameter -and $Parameter.Count -gt 0)

--- a/source/Private/New-GuestConfigurationPolicyParametersSection.ps1
+++ b/source/Private/New-GuestConfigurationPolicyParametersSection.ps1
@@ -6,11 +6,23 @@ function New-GuestConfigurationPolicyParametersSection
     (
         [Parameter()]
         [Hashtable[]]
-        $Parameter
+        $Parameter,
+
+        [Parameter()]
+        [Switch]
+        $ExcludeArcMachines
     )
 
     $templateFileName = '2-Parameters.json'
     $parametersSection = Get-GuestConfigurationPolicySectionFromTemplate -FileName $templateFileName
+
+    if ($ExcludeArcMachines)
+    {
+        if ($parametersSection.parameters.IncludeArcMachines)
+        {
+            $parametersSection.parameters.Remove("IncludeArcMachines")
+        }
+    }
 
     foreach ($currentParameter in $Parameter)
     {

--- a/source/Private/New-GuestConfigurationPolicySetActionSection.ps1
+++ b/source/Private/New-GuestConfigurationPolicySetActionSection.ps1
@@ -20,7 +20,7 @@ function New-GuestConfigurationPolicySetActionSection
 
         [Parameter()]
         [String]
-        $ContentManagedIdentity,
+        $ManagedIdentityResourceId,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
@@ -75,9 +75,9 @@ function New-GuestConfigurationPolicySetActionSection
         assignmentType = $AssignmentType
     }
 
-    if ($ContentManagedIdentity)
+    if (-not [string]::IsNullOrWhiteSpace($ManagedIdentityResourceId))
     {
-        $guestConfigMetadataSection.contentManagedIdentity = $ContentManagedIdentity
+        $guestConfigMetadataSection.contentManagedIdentity = $ManagedIdentityResourceId
     }
 
     if ($null -ne $Parameter -and $Parameter.Count -gt 0)

--- a/source/Private/New-GuestConfigurationPolicySetActionSection.ps1
+++ b/source/Private/New-GuestConfigurationPolicySetActionSection.ps1
@@ -18,6 +18,10 @@ function New-GuestConfigurationPolicySetActionSection
         [String]
         $ContentUri,
 
+        [Parameter()]
+        [String]
+        $ContentManagedIdentity,
+
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [String]
@@ -69,6 +73,11 @@ function New-GuestConfigurationPolicySetActionSection
         contentUri = $ContentUri
         contentHash = $ContentHash
         assignmentType = $AssignmentType
+    }
+
+    if ($ContentManagedIdentity)
+    {
+        $guestConfigMetadataSection.contentManagedIdentity = $ContentManagedIdentity
     }
 
     if ($null -ne $Parameter -and $Parameter.Count -gt 0)

--- a/source/Public/New-GuestConfigurationPolicy.ps1
+++ b/source/Public/New-GuestConfigurationPolicy.ps1
@@ -450,15 +450,10 @@ function New-GuestConfigurationPolicy
         Tag = $Tag
         IncludeVMSS = $IncludeVMSS
     }
-    
+
     if (-not ([string]::IsNullOrWhiteSpace($ManagedIdentityResourceId) -or [string]::IsNullOrWhiteSpace($ContentPath)))
     {
-        $policyDefinitionContentParameters.ContentManagedIdentity = $ManagedIdentityResourceId
-    }
-
-    if ($ContentManagedIdentity -and $ContentPath)
-    {
-        $policyDefinitionContentParameters.ContentManagedIdentity = $ContentManagedIdentity
+        $policyDefinitionContentParameters.ManagedIdentityResourceId = $ManagedIdentityResourceId
     }
 
     $policyDefinitionContent = New-GuestConfigurationPolicyContent @policyDefinitionContentParameters

--- a/source/Public/New-GuestConfigurationPolicy.ps1
+++ b/source/Public/New-GuestConfigurationPolicy.ps1
@@ -34,7 +34,7 @@
         Note: If you are using an Azure storage account to store the custom machine configuration package artifact, you have two options for access:
         1. Generate a blob shared access signature (SAS) token with read access and provide the full blob URI with the SAS token for the ContentUri parameter.
         2. Create a user-assigned managed identity with read access to the storage account blob containing the package.
-            Provide the resource ID of the managed identity, a local path to the zipped package, and a URI to the package without a SAS token for the ManagedIdentityResourceId, LocalContentPath, and ContentUri parameters.
+            Provide the resource ID of the managed identity, a local path to the zipped package, a URI to the package without a SAS token and the ExcludeArcMachines parameter.
             With this option, once the generated policy is applied, the managed identity will be used to download the package onto the target machine.
 
     .PARAMETER ManagedIdentityResourceId
@@ -42,7 +42,7 @@
         The value for this parameter needs to be the resource id of the managed identity.
         This is an option to use when the package is stored in a storage account and the storage account is protected by a managed identity.
 
-        Note: optional parameter. If this is specified, LocalContentPath must also be specified.
+        Note: optional parameter. If this is specified, LocalContentPath and ExcludeArcMachines must also be specified.
 
     .PARAMETER LocalContentPath
         This is the path to the local package zip file. This is used to calculate the hash of the package.
@@ -259,7 +259,7 @@ function New-GuestConfigurationPolicy
 
     if ($PSCmdlet.ParameterSetName -eq 'ManagedIdentity' -and ([string]::IsNullOrWhiteSpace($ManagedIdentityResourceId) -or [string]::IsNullOrWhiteSpace($LocalContentPath)))
     {
-        throw "Both ManagedIdentityResourceId and LocalContentPath must be provided together."
+        throw "Both ManagedIdentityResourceId and LocalContentPath must be provided together. Please include ManagedIdentityResourceId, LocalContentPath, and ExcludeArcMachines parameters."
     }
 
     $requiredParameterProperties = @('Name', 'DisplayName', 'Description', 'ResourceType', 'ResourceId', 'ResourcePropertyName')
@@ -463,7 +463,7 @@ function New-GuestConfigurationPolicy
         IncludeVMSS = $IncludeVMSS
     }
 
-    if (-not ([string]::IsNullOrWhiteSpace($ManagedIdentityResourceId) -or [string]::IsNullOrWhiteSpace($LocalContentPath)))
+    if (-not [string]::IsNullOrWhiteSpace($ManagedIdentityResourceId))
     {
         $policyDefinitionContentParameters.ManagedIdentityResourceId = $ManagedIdentityResourceId
     }

--- a/tests/Public/New-GuestConfigurationPolicy.Tests.ps1
+++ b/tests/Public/New-GuestConfigurationPolicy.Tests.ps1
@@ -691,13 +691,13 @@ Describe 'New-GuestConfigurationPolicy' {
                     }
                 }
 
-                Context 'New parameters - contentManagedIdentity and contentPath' {
+                Context 'Optional identity parameters - ManagedIdentityResourceId and contentPath' {
                     BeforeAll {
                         $fileName = $ContentUri.Split('/')[-1]
                         $filePath = Join-Path -Path $defaultDefinitionsPath -ChildPath $fileName
                         Invoke-WebRequest $ContentUri -OutFile $filePath
 
-                        $basePolicyParameters['ContentManagedIdentity'] = 'myManagedIdentity'
+                        $basePolicyParameters['ManagedIdentityResourceId'] = 'myManagedIdentity'
                         $basePolicyParameters['ContentPath'] = $filePath
                         $baseAssertionParameters['ExpectedManagedIdentity'] = 'myManagedIdentity'
                     }
@@ -717,32 +717,32 @@ Describe 'New-GuestConfigurationPolicy' {
                     }
                 }
 
-                Context 'New parameters - contentManagedIdentity without contentPath' {
+                Context 'New parameters - ManagedIdentityResourceId without contentPath' {
                     BeforeAll {
-                        $basePolicyParameters['ContentManagedIdentity'] = 'myManagedIdentity'
+                        $basePolicyParameters['ManagedIdentityResourceId'] = 'myManagedIdentity'
                         $basePolicyParameters['ContentPath'] = $null
 
                     }
 
                     It 'Should throw a missing parameter exception if one of the parameters is missing' {
-                        { New-GuestConfigurationPolicy @basePolicyParameters } | Should -Throw -ExpectedMessage 'Both ContentManagedIdentity and ContentPath must be provided together.'
+                        { New-GuestConfigurationPolicy @basePolicyParameters } | Should -Throw -ExpectedMessage 'Both ManagedIdentityResourceId and ContentPath must be provided together.'
                     }
                 }
 
-                Context 'New parameters - contentPath without contentManagedIdentity' {
+                Context 'New parameters - contentPath without ManagedIdentityResourceId' {
                     BeforeAll {
                         $fileName = $ContentUri.Split('/')[-1]
                         $filePath = Join-Path -Path $defaultDefinitionsPath -ChildPath $fileName
                         Invoke-WebRequest $ContentUri -OutFile $filePath
 
                         $basePolicyParameters['ContentPath'] = $filePath
-                        $basePolicyParameters['ContentManagedIdentity'] = $null
+                        $basePolicyParameters['ManagedIdentityResourceId'] = $null
 
                         Remove-Item -Path $filePath
                     }
 
                     It 'Should throw a missing parameter exception if one of the parameters is missing' {
-                        { New-GuestConfigurationPolicy @basePolicyParameters } | Should -Throw -ExpectedMessage 'Both ContentManagedIdentity and ContentPath must be provided together.'
+                        { New-GuestConfigurationPolicy @basePolicyParameters } | Should -Throw -ExpectedMessage 'Both ManagedIdentityResourceId and ContentPath must be provided together.'
                     }
                 }
             }

--- a/tests/Public/New-GuestConfigurationPolicy.Tests.ps1
+++ b/tests/Public/New-GuestConfigurationPolicy.Tests.ps1
@@ -691,19 +691,19 @@ Describe 'New-GuestConfigurationPolicy' {
                     }
                 }
 
-                Context 'Optional identity parameters - ManagedIdentityResourceId and contentPath' {
+                Context 'Optional identity parameters - ManagedIdentityResourceId and LocalContentPath with ExcludeArcMachines' {
                     BeforeAll {
                         $fileName = $ContentUri.Split('/')[-1]
                         $filePath = Join-Path -Path $defaultDefinitionsPath -ChildPath $fileName
                         Invoke-WebRequest $ContentUri -OutFile $filePath
 
                         $basePolicyParameters['ManagedIdentityResourceId'] = 'myManagedIdentity'
-                        $basePolicyParameters['ContentPath'] = $filePath
+                        $basePolicyParameters['LocalContentPath'] = $filePath
                         $baseAssertionParameters['ExpectedManagedIdentity'] = 'myManagedIdentity'
                     }
 
                     It 'Should include contentManagedIdentity in the result object' {
-                        $result = New-GuestConfigurationPolicy @basePolicyParameters
+                        $result = New-GuestConfigurationPolicy @basePolicyParameters -ExcludeArcMachines
 
                         $result | Should -Not -BeNull
 
@@ -717,32 +717,46 @@ Describe 'New-GuestConfigurationPolicy' {
                     }
                 }
 
-                Context 'New parameters - ManagedIdentityResourceId without contentPath' {
-                    BeforeAll {
-                        $basePolicyParameters['ManagedIdentityResourceId'] = 'myManagedIdentity'
-                        $basePolicyParameters['ContentPath'] = $null
-
-                    }
-
-                    It 'Should throw a missing parameter exception if one of the parameters is missing' {
-                        { New-GuestConfigurationPolicy @basePolicyParameters } | Should -Throw -ExpectedMessage 'Both ManagedIdentityResourceId and ContentPath must be provided together.'
-                    }
-                }
-
-                Context 'New parameters - contentPath without ManagedIdentityResourceId' {
+                Context 'Optional identity parameters - ManagedIdentityResourceId and LocalContentPath without ExcludeArcMachines' {
                     BeforeAll {
                         $fileName = $ContentUri.Split('/')[-1]
                         $filePath = Join-Path -Path $defaultDefinitionsPath -ChildPath $fileName
                         Invoke-WebRequest $ContentUri -OutFile $filePath
 
-                        $basePolicyParameters['ContentPath'] = $filePath
+                        $basePolicyParameters['ManagedIdentityResourceId'] = 'myManagedIdentity'
+                        $basePolicyParameters['LocalContentPath'] = $filePath
+                    }
+
+                    It 'Should throw a exception if ExcludeArcMachines is not specified' {
+                        { New-GuestConfigurationPolicy @basePolicyParameters } | Should -Throw -ExpectedMessage 'Custom policies that reference User Assigned Identities will not include Arc enabled servers in the definition. Use -ExcludeArcMachines to continue.'
+                    }
+                }
+
+                Context 'Optional identity parameters - ManagedIdentityResourceId without LocalContentPath' {
+                    BeforeAll {
+                        $basePolicyParameters['ManagedIdentityResourceId'] = 'myManagedIdentity'
+                        $basePolicyParameters['LocalContentPath'] = $null
+                    }
+
+                    It 'Should throw a missing parameter exception if one of the parameters is missing' {
+                        { New-GuestConfigurationPolicy @basePolicyParameters } | Should -Throw -ExpectedMessage 'Both ManagedIdentityResourceId and LocalContentPath must be provided together.'
+                    }
+                }
+
+                Context 'Optional identity parameters - LocalContentPath without ManagedIdentityResourceId' {
+                    BeforeAll {
+                        $fileName = $ContentUri.Split('/')[-1]
+                        $filePath = Join-Path -Path $defaultDefinitionsPath -ChildPath $fileName
+                        Invoke-WebRequest $ContentUri -OutFile $filePath
+
+                        $basePolicyParameters['LocalContentPath'] = $filePath
                         $basePolicyParameters['ManagedIdentityResourceId'] = $null
 
                         Remove-Item -Path $filePath
                     }
 
                     It 'Should throw a missing parameter exception if one of the parameters is missing' {
-                        { New-GuestConfigurationPolicy @basePolicyParameters } | Should -Throw -ExpectedMessage 'Both ManagedIdentityResourceId and ContentPath must be provided together.'
+                        { New-GuestConfigurationPolicy @basePolicyParameters } | Should -Throw -ExpectedMessage 'Both ManagedIdentityResourceId and LocalContentPath must be provided together.'
                     }
                 }
             }

--- a/tests/Public/New-GuestConfigurationPolicy.Tests.ps1
+++ b/tests/Public/New-GuestConfigurationPolicy.Tests.ps1
@@ -729,7 +729,7 @@ Describe 'New-GuestConfigurationPolicy' {
                         $fileContent = Get-Content -Path $result.Path -Raw
                         $fileContentJson = $fileContent | ConvertFrom-Json
 
-                        $fileContentJson.properties.metadata.guestConfiguration.contentManagedIdentity | Should -BeNullOrEmpty
+                        $fileContentJson.properties.metadata.guestConfiguration.PSObject.Properties.Match('contentManagedIdentity').Count | Should -Be 0
 
                         # Check Hybrid section removed
                         $imageConditionList = $fileContentJson.properties.policyRule.if.anyOf


### PR DESCRIPTION
A new field - contentManagedIdentity would be part of the policy definition.
This field can be used to download the policy package from storage blob using user assigned identities.

The identity is used to receive a token from IMDS which in turn is used to get the package from the storage account container blob.

Adding these fields is like a replacement to the sas url.

Custom policies that reference the resource ID of a User Assigned Identity are not supported on Arc machines. The generated policy definition will not include Arc enabled servers to prevent execution. 