### PR TITLE
Added system assigned identity to download custom policy packages

### DIFF
--- a/source/Public/New-GuestConfigurationPolicy.ps1
+++ b/source/Public/New-GuestConfigurationPolicy.ps1
@@ -275,7 +275,7 @@ function New-GuestConfigurationPolicy
         {
             if ([string]::IsNullOrWhiteSpace($ManagedIdentityResourceId) -and -not $UseSystemAssignmentIdentity)
             {
-                throw "If LocalContentPath is provided then please include either ManagedIdentityResourceId with ExcludeArchMachine or UseSystemAssignmentIdentity."
+                throw "If LocalContentPath is provided then please include either ManagedIdentityResourceId with ExcludeArcMachine or UseSystemAssignmentIdentity."
             }
             elseif (-not [string]::IsNullOrWhiteSpace($ManagedIdentityResourceId) -and $UseSystemAssignmentIdentity)
             {
@@ -286,7 +286,7 @@ function New-GuestConfigurationPolicy
         {
             if ($ManagedIdentityResourceId -or $UseSystemAssignmentIdentity)
             {
-                throw "If ManagedIdentityResourceId with ExcludeArchMachine or UseSystemAssignmentIdentity is enabled please include the LocalContentPath with the path to the local package."
+                throw "If ManagedIdentityResourceId with ExcludeArcMachine or UseSystemAssignmentIdentity is enabled please include the LocalContentPath with the path to the local package."
             }
         }
     }

--- a/source/Public/New-GuestConfigurationPolicy.ps1
+++ b/source/Public/New-GuestConfigurationPolicy.ps1
@@ -275,18 +275,18 @@ function New-GuestConfigurationPolicy
         {
             if ([string]::IsNullOrWhiteSpace($ManagedIdentityResourceId) -and -not $UseSystemAssignmentIdentity)
             {
-                throw "If LocalContentPath is provided then please include either ManagedIdentityResourceId with ExcludeArcMachine or UseSystemAssignmentIdentity."
+                throw "Please provide input to the LocalContentPath parameter to use either the -UseSystemAssignedIdentity flag or the ManagedIdentityResourceId parameter with the -ExcludeArcMachine flag"
             }
             elseif (-not [string]::IsNullOrWhiteSpace($ManagedIdentityResourceId) -and $UseSystemAssignmentIdentity)
             {
-                throw "Both ManagedIdentityResourceId and UseSystemAssignmentIdentity cannot be provided together."
+                throw "The ManagedIdentityResourceId parameter and UseSystemAssignedIdentity flag cannot be provided together."
             }
         }
         else
         {
             if ($ManagedIdentityResourceId -or $UseSystemAssignmentIdentity)
             {
-                throw "If ManagedIdentityResourceId with ExcludeArcMachine or UseSystemAssignmentIdentity is enabled please include the LocalContentPath with the path to the local package."
+                throw "Please provide input to the LocalContentPath parameter to use either the -UseSystemAssignedIdentity flag or the ManagedIdentityResourceId parameter with the -ExcludeArcMachine flag"
             }
         }
     }

--- a/source/Public/New-GuestConfigurationPolicy.ps1
+++ b/source/Public/New-GuestConfigurationPolicy.ps1
@@ -275,7 +275,7 @@ function New-GuestConfigurationPolicy
         {
             if ([string]::IsNullOrWhiteSpace($ManagedIdentityResourceId) -and -not $UseSystemAssignedIdentity)
             {
-                throw "Please provide input to the LocalContentPath parameter to use either the -UseSystemAssignedIdentity flag or the ManagedIdentityResourceId parameter with the -ExcludeArcMachine flag"
+                throw "Please specify either the -UseSystemAssignmentIdentity flag or ManagedIdentityResourceId parameter with the -ExcludeArcMachine flag when providing input to the LocalContentPath parameter."
             }
             elseif (-not [string]::IsNullOrWhiteSpace($ManagedIdentityResourceId) -and $UseSystemAssignedIdentity)
             {
@@ -284,9 +284,9 @@ function New-GuestConfigurationPolicy
         }
         else
         {
-            if ($ManagedIdentityResourceId -or $UseSystemAssignedIdentity)
+            if (-not [string]::IsNullOrWhiteSpace($ManagedIdentityResourceId) -or $UseSystemAssignedIdentity)
             {
-                throw "Please provide input to the LocalContentPath parameter to use either the -UseSystemAssignedIdentity flag or the ManagedIdentityResourceId parameter with the -ExcludeArcMachine flag"
+                throw "Please provide input to the LocalContentPath parameter to use either the -UseSystemAssignedIdentity flag or the ManagedIdentityResourceId parameter with the -ExcludeArcMachine flag."
             }
         }
     }
@@ -355,7 +355,7 @@ function New-GuestConfigurationPolicy
         {
             if (-not $ExcludeArcMachines)
             {
-                throw "The ManagedIdentityResourceId (user-assigned identity) and LocalContentPath parameters are defined but the -ExcludeArcMachines parameter is not. User assigned Managed identities cannot be used with Azure Arc machines. Please provide the -ExcludeArcMachines parameter to exclude Azure Arc machines and use a managed identity with this policy."
+                throw "The ManagedIdentityResourceId and LocalContentPath parameters are defined but the -ExcludeArcMachines parameter is not. User assigned managed identities cannot be used with Azure Arc machines. Please provide the -ExcludeArcMachines parameter to exclude Azure Arc machines and use a managed identity with this policy."
             }
 
             $packageFileDownloadPath = $LocalContentPath

--- a/source/Public/New-GuestConfigurationPolicy.ps1
+++ b/source/Public/New-GuestConfigurationPolicy.ps1
@@ -38,7 +38,7 @@
             With this option, once the generated policy is applied, the managed identity will be used to download the package onto the target machine.
 
     .PARAMETER ManagedIdentityResourceId
-        This is the identity that is used to download the package from storage account container instead of using SaS url.
+        This is the identity that is used to download the package from storage account container instead of using SAS url.
         The value for this parameter needs to be the resource id of the managed identity.
         This is an option to use when the package is stored in a storage account and the storage account is protected by a managed identity.
 

--- a/source/Public/New-GuestConfigurationPolicy.ps1
+++ b/source/Public/New-GuestConfigurationPolicy.ps1
@@ -44,7 +44,7 @@
 
         Note: optional parameter. If this is specified, LocalContentPath and ExcludeArcMachines must also be specified.
 
-    .PARAMETER UseSystemAssignmentIdentity
+    .PARAMETER UseSystemAssignedIdentity
         This is the option to use the system assigned identity for downloading package from storage account container instead of using SaS url.
         When this option is enabled you cannot use the ManagedIdentityResourceId. Only one of the options should be used at a time.
         You can use this parameter without ExcludeArcMachines option as the system assigned identity is available for Arc machines.
@@ -210,7 +210,7 @@ function New-GuestConfigurationPolicy
 
         [Parameter(ParameterSetName='ManagedIdentity')]
         [Switch]
-        $UseSystemAssignmentIdentity,
+        $UseSystemAssignedIdentity,
 
         [Parameter()]
         [System.Version]
@@ -273,18 +273,18 @@ function New-GuestConfigurationPolicy
     {
         if (-not [string]::IsNullOrWhiteSpace($LocalContentPath))
         {
-            if ([string]::IsNullOrWhiteSpace($ManagedIdentityResourceId) -and -not $UseSystemAssignmentIdentity)
+            if ([string]::IsNullOrWhiteSpace($ManagedIdentityResourceId) -and -not $UseSystemAssignedIdentity)
             {
                 throw "Please provide input to the LocalContentPath parameter to use either the -UseSystemAssignedIdentity flag or the ManagedIdentityResourceId parameter with the -ExcludeArcMachine flag"
             }
-            elseif (-not [string]::IsNullOrWhiteSpace($ManagedIdentityResourceId) -and $UseSystemAssignmentIdentity)
+            elseif (-not [string]::IsNullOrWhiteSpace($ManagedIdentityResourceId) -and $UseSystemAssignedIdentity)
             {
                 throw "The ManagedIdentityResourceId parameter and UseSystemAssignedIdentity flag cannot be provided together."
             }
         }
         else
         {
-            if ($ManagedIdentityResourceId -or $UseSystemAssignmentIdentity)
+            if ($ManagedIdentityResourceId -or $UseSystemAssignedIdentity)
             {
                 throw "Please provide input to the LocalContentPath parameter to use either the -UseSystemAssignedIdentity flag or the ManagedIdentityResourceId parameter with the -ExcludeArcMachine flag"
             }
@@ -361,13 +361,13 @@ function New-GuestConfigurationPolicy
             $packageFileDownloadPath = $LocalContentPath
         }
         # This means the customer wants to use the System-Assigned id.
-        elseif ($UseSystemAssignmentIdentity)
+        elseif ($UseSystemAssignedIdentity)
         {
             $packageFileDownloadPath = $LocalContentPath
         }
         else
         {
-            throw "The LocalContentPath is defined but either of the identity is not given. Please provide ManagedIdentityResourceId along with ExcludeArcMachine or use flag UseSystemAssignmentIdentity."
+            throw "The LocalContentPath is defined but either of the identity is not given. Please provide ManagedIdentityResourceId along with ExcludeArcMachine or use flag UseSystemAssignedIdentity."
         }
     }
     else
@@ -510,7 +510,7 @@ function New-GuestConfigurationPolicy
     {
         $policyDefinitionContentParameters.ManagedIdentityResourceId = $ManagedIdentityResourceId
     }
-    elseif ($UseSystemAssignmentIdentity)
+    elseif ($UseSystemAssignedIdentity)
     {
         $policyDefinitionContentParameters.ManagedIdentityResourceId = "system"
     }

--- a/tests/Public/New-GuestConfigurationPolicy.Tests.ps1
+++ b/tests/Public/New-GuestConfigurationPolicy.Tests.ps1
@@ -697,7 +697,7 @@ Describe 'New-GuestConfigurationPolicy' {
                     }
                 }
 
-                Context 'Optional identity parameters - ManagedIdentityResourceId and ExcludeArcMachines or UseSystemAssignmentIdentity and LocalContentPath' {
+                Context 'Optional identity parameters - ManagedIdentityResourceId and ExcludeArcMachines or UseSystemAssignedIdentity and LocalContentPath' {
                     BeforeAll {
                         $fileName = $ContentUri.Split('/')[-1]
                         $filePath = Join-Path -Path $defaultDefinitionsPath -ChildPath $fileName
@@ -729,11 +729,11 @@ Describe 'New-GuestConfigurationPolicy' {
                         $baseAssertionParameters.Remove('ExpectedManagedIdentity')
                     }
 
-                    It 'Should include contentManagedIdentity - UseSystemAssignmentIdentity in the result object and exclude Arc machines' {
+                    It 'Should include contentManagedIdentity - UseSystemAssignedIdentity in the result object and exclude Arc machines' {
                         $basePolicyParameters['LocalContentPath'] = $filePath
                         $baseAssertionParameters['ExpectedManagedIdentity'] = 'system'
 
-                        $result = New-GuestConfigurationPolicy @basePolicyParameters -ExcludeArcMachines -UseSystemAssignmentIdentity
+                        $result = New-GuestConfigurationPolicy @basePolicyParameters -ExcludeArcMachines -UseSystemAssignedIdentity
 
                         $result | Should -Not -BeNull
 
@@ -752,11 +752,11 @@ Describe 'New-GuestConfigurationPolicy' {
                         $baseAssertionParameters.Remove('ExpectedManagedIdentity')
                     }
 
-                    It 'Should include contentManagedIdentity - UseSystemAssignmentIdentity in the result object and not exclude Arc machines' {
+                    It 'Should include contentManagedIdentity - UseSystemAssignedIdentity in the result object and not exclude Arc machines' {
                         $basePolicyParameters['LocalContentPath'] = $filePath
                         $baseAssertionParameters['ExpectedManagedIdentity'] = 'system'
 
-                        $result = New-GuestConfigurationPolicy @basePolicyParameters -UseSystemAssignmentIdentity
+                        $result = New-GuestConfigurationPolicy @basePolicyParameters -UseSystemAssignedIdentity
 
                         $result | Should -Not -BeNull
 
@@ -812,7 +812,7 @@ Describe 'New-GuestConfigurationPolicy' {
                         $basePolicyParameters.Remove('LocalContentPath')
                     }
 
-                    It 'Should throw a missing parameter exception if ManagedIdentityResourceId or UseSystemAssignmentIdentity is missing but LocalContentPath is provided' {
+                    It 'Should throw a missing parameter exception if ManagedIdentityResourceId or UseSystemAssignedIdentity is missing but LocalContentPath is provided' {
                         $basePolicyParameters['LocalContentPath'] = $filePath
                         $basePolicyParameters['ManagedIdentityResourceId'] = $null
 
@@ -827,7 +827,7 @@ Describe 'New-GuestConfigurationPolicy' {
                         $basePolicyParameters['ManagedIdentityResourceId'] = $null
                         $basePolicyParameters['LocalContentPath'] = $null
 
-                        { New-GuestConfigurationPolicy @basePolicyParameters -UseSystemAssignmentIdentity } | Should -Throw -ExpectedMessage 'If ManagedIdentityResourceId with ExcludeArcMachine or UseSystemAssignmentIdentity is enabled please include the LocalContentPath with the path to the local package.'
+                        { New-GuestConfigurationPolicy @basePolicyParameters -UseSystemAssignedIdentity } | Should -Throw -ExpectedMessage 'If ManagedIdentityResourceId with ExcludeArcMachine or UseSystemAssignedIdentity is enabled please include the LocalContentPath with the path to the local package.'
 
                         $basePolicyParameters.Remove('ManagedIdentityResourceId')
                         $basePolicyParameters.Remove('LocalContentPath')

--- a/tests/Public/New-GuestConfigurationPolicy.Tests.ps1
+++ b/tests/Public/New-GuestConfigurationPolicy.Tests.ps1
@@ -806,7 +806,7 @@ Describe 'New-GuestConfigurationPolicy' {
                         $basePolicyParameters['ManagedIdentityResourceId'] = 'myManagedIdentity'
                         $basePolicyParameters['LocalContentPath'] = $null
 
-                        { New-GuestConfigurationPolicy @basePolicyParameters } | Should -Throw -ExpectedMessage 'If ManagedIdentityResourceId with ExcludeArcMachine or UseSystemAssignmentIdentity is enabled please include the LocalContentPath with the path to the local package.'
+                        { New-GuestConfigurationPolicy @basePolicyParameters } | Should -Throw -ExpectedMessage 'Please provide input to the LocalContentPath parameter to use either the -UseSystemAssignedIdentity flag or the ManagedIdentityResourceId parameter with the -ExcludeArcMachine flag'
 
                         $basePolicyParameters.Remove('ManagedIdentityResourceId')
                         $basePolicyParameters.Remove('LocalContentPath')

--- a/tests/Public/New-GuestConfigurationPolicy.Tests.ps1
+++ b/tests/Public/New-GuestConfigurationPolicy.Tests.ps1
@@ -806,7 +806,7 @@ Describe 'New-GuestConfigurationPolicy' {
                         $basePolicyParameters['ManagedIdentityResourceId'] = 'myManagedIdentity'
                         $basePolicyParameters['LocalContentPath'] = $null
 
-                        { New-GuestConfigurationPolicy @basePolicyParameters } | Should -Throw -ExpectedMessage 'If ManagedIdentityResourceId with ExcludeArchMachine or UseSystemAssignmentIdentity is enabled please include the LocalContentPath with the path to the local package.'
+                        { New-GuestConfigurationPolicy @basePolicyParameters } | Should -Throw -ExpectedMessage 'If ManagedIdentityResourceId with ExcludeArcMachine or UseSystemAssignmentIdentity is enabled please include the LocalContentPath with the path to the local package.'
 
                         $basePolicyParameters.Remove('ManagedIdentityResourceId')
                         $basePolicyParameters.Remove('LocalContentPath')
@@ -827,7 +827,7 @@ Describe 'New-GuestConfigurationPolicy' {
                         $basePolicyParameters['ManagedIdentityResourceId'] = $null
                         $basePolicyParameters['LocalContentPath'] = $null
 
-                        { New-GuestConfigurationPolicy @basePolicyParameters -UseSystemAssignmentIdentity } | Should -Throw -ExpectedMessage 'If ManagedIdentityResourceId with ExcludeArchMachine or UseSystemAssignmentIdentity is enabled please include the LocalContentPath with the path to the local package.'
+                        { New-GuestConfigurationPolicy @basePolicyParameters -UseSystemAssignmentIdentity } | Should -Throw -ExpectedMessage 'If ManagedIdentityResourceId with ExcludeArcMachine or UseSystemAssignmentIdentity is enabled please include the LocalContentPath with the path to the local package.'
 
                         $basePolicyParameters.Remove('ManagedIdentityResourceId')
                         $basePolicyParameters.Remove('LocalContentPath')

--- a/tests/Public/New-GuestConfigurationPolicy.Tests.ps1
+++ b/tests/Public/New-GuestConfigurationPolicy.Tests.ps1
@@ -796,7 +796,7 @@ Describe 'New-GuestConfigurationPolicy' {
                         $basePolicyParameters['ManagedIdentityResourceId'] = 'myManagedIdentity'
                         $basePolicyParameters['LocalContentPath'] = $filePath
 
-                        { New-GuestConfigurationPolicy @basePolicyParameters } | Should -Throw -ExpectedMessage 'The ManagedIdentityResourceId (user-assigned identity) and LocalContentPath parameters are defined but the -ExcludeArcMachines parameter is not. User assigned Managed identities cannot be used with Azure Arc machines. Please provide the -ExcludeArcMachines parameter to exclude Azure Arc machines and use a managed identity with this policy.'
+                        { New-GuestConfigurationPolicy @basePolicyParameters } | Should -Throw -ExpectedMessage 'The ManagedIdentityResourceId and LocalContentPath parameters are defined but the -ExcludeArcMachines parameter is not. User assigned managed identities cannot be used with Azure Arc machines. Please provide the -ExcludeArcMachines parameter to exclude Azure Arc machines and use a managed identity with this policy.'
 
                         $basePolicyParameters.Remove('ManagedIdentityResourceId')
                         $basePolicyParameters.Remove('LocalContentPath')
@@ -806,7 +806,7 @@ Describe 'New-GuestConfigurationPolicy' {
                         $basePolicyParameters['ManagedIdentityResourceId'] = 'myManagedIdentity'
                         $basePolicyParameters['LocalContentPath'] = $null
 
-                        { New-GuestConfigurationPolicy @basePolicyParameters } | Should -Throw -ExpectedMessage 'Please provide input to the LocalContentPath parameter to use either the -UseSystemAssignedIdentity flag or the ManagedIdentityResourceId parameter with the -ExcludeArcMachine flag'
+                        { New-GuestConfigurationPolicy @basePolicyParameters } | Should -Throw -ExpectedMessage 'Please provide input to the LocalContentPath parameter to use either the -UseSystemAssignedIdentity flag or the ManagedIdentityResourceId parameter with the -ExcludeArcMachine flag.'
 
                         $basePolicyParameters.Remove('ManagedIdentityResourceId')
                         $basePolicyParameters.Remove('LocalContentPath')
@@ -816,7 +816,7 @@ Describe 'New-GuestConfigurationPolicy' {
                         $basePolicyParameters['LocalContentPath'] = $filePath
                         $basePolicyParameters['ManagedIdentityResourceId'] = $null
 
-                        { New-GuestConfigurationPolicy @basePolicyParameters } | Should -Throw -ExpectedMessage 'Both ManagedIdentityResourceId and LocalContentPath must be provided together. Please include ManagedIdentityResourceId, LocalContentPath, and ExcludeArcMachines parameters.'
+                        { New-GuestConfigurationPolicy @basePolicyParameters } | Should -Throw -ExpectedMessage 'Please specify either the -UseSystemAssignmentIdentity flag or ManagedIdentityResourceId parameter with the -ExcludeArcMachine flag when providing input to the LocalContentPath parameter.'
 
 
                         $basePolicyParameters.Remove('ManagedIdentityResourceId')
@@ -827,7 +827,7 @@ Describe 'New-GuestConfigurationPolicy' {
                         $basePolicyParameters['ManagedIdentityResourceId'] = $null
                         $basePolicyParameters['LocalContentPath'] = $null
 
-                        { New-GuestConfigurationPolicy @basePolicyParameters -UseSystemAssignedIdentity } | Should -Throw -ExpectedMessage 'If ManagedIdentityResourceId with ExcludeArcMachine or UseSystemAssignedIdentity is enabled please include the LocalContentPath with the path to the local package.'
+                        { New-GuestConfigurationPolicy @basePolicyParameters -UseSystemAssignedIdentity } | Should -Throw -ExpectedMessage 'Please provide input to the LocalContentPath parameter to use either the -UseSystemAssignedIdentity flag or the ManagedIdentityResourceId parameter with the -ExcludeArcMachine flag.'
 
                         $basePolicyParameters.Remove('ManagedIdentityResourceId')
                         $basePolicyParameters.Remove('LocalContentPath')

--- a/tests/Public/New-GuestConfigurationPolicy.Tests.ps1
+++ b/tests/Public/New-GuestConfigurationPolicy.Tests.ps1
@@ -816,7 +816,7 @@ Describe 'New-GuestConfigurationPolicy' {
                         $basePolicyParameters['ManagedIdentityResourceId'] = 'myManagedIdentity'
                         $basePolicyParameters['LocalContentPath'] = $filePath
 
-                        { New-GuestConfigurationPolicy @basePolicyParameters } | Should -Throw -ExpectedMessage 'The ManagedIdentityResourceId and LocalContentPath parameters are defined but the -ExcludeArcMachines parameter is not. User assigned managed identities cannot be used with Azure Arc machines. Please provide the -ExcludeArcMachines parameter to exclude Azure Arc machines and use a managed identity with this policy.'
+                        { New-GuestConfigurationPolicy @basePolicyParameters } | Should -Throw -ExpectedMessage 'The ManagedIdentityResourceId parameter is defined but the ExcludeArcMachines flag is not provided. User assigned managed identities cannot be used with Azure Arc machines.'
 
                         $basePolicyParameters.Remove('ManagedIdentityResourceId')
                         $basePolicyParameters.Remove('LocalContentPath')
@@ -826,7 +826,7 @@ Describe 'New-GuestConfigurationPolicy' {
                         $basePolicyParameters['ManagedIdentityResourceId'] = 'myManagedIdentity'
                         $basePolicyParameters['LocalContentPath'] = $null
 
-                        { New-GuestConfigurationPolicy @basePolicyParameters } | Should -Throw -ExpectedMessage 'Please provide input to the LocalContentPath parameter to use either the -UseSystemAssignedIdentity flag or the ManagedIdentityResourceId parameter with the -ExcludeArcMachine flag.'
+                        { New-GuestConfigurationPolicy @basePolicyParameters } | Should -Throw -ExpectedMessage 'Please provide input to the LocalContentPath parameter to use the ManagedIdentityResourceId parameter.'
 
                         $basePolicyParameters.Remove('ManagedIdentityResourceId')
                         $basePolicyParameters.Remove('LocalContentPath')
@@ -836,7 +836,7 @@ Describe 'New-GuestConfigurationPolicy' {
                         $basePolicyParameters['LocalContentPath'] = $filePath
                         $basePolicyParameters['ManagedIdentityResourceId'] = $null
 
-                        { New-GuestConfigurationPolicy @basePolicyParameters } | Should -Throw -ExpectedMessage 'Please specify either the -UseSystemAssignmentIdentity flag or ManagedIdentityResourceId parameter with the -ExcludeArcMachine flag when providing input to the LocalContentPath parameter.'
+                        { New-GuestConfigurationPolicy @basePolicyParameters } | Should -Throw -ExpectedMessage 'LocalContentPath was provided, but no identity parameters were specified. Please include either the UseSystemAssignedIdentity or ManagedIdentityResourceId with LocalContentPath.'
 
 
                         $basePolicyParameters.Remove('ManagedIdentityResourceId')
@@ -847,9 +847,29 @@ Describe 'New-GuestConfigurationPolicy' {
                         $basePolicyParameters['ManagedIdentityResourceId'] = $null
                         $basePolicyParameters['LocalContentPath'] = $null
 
-                        { New-GuestConfigurationPolicy @basePolicyParameters -UseSystemAssignedIdentity } | Should -Throw -ExpectedMessage 'Please provide input to the LocalContentPath parameter to use either the -UseSystemAssignedIdentity flag or the ManagedIdentityResourceId parameter with the -ExcludeArcMachine flag.'
+                        { New-GuestConfigurationPolicy @basePolicyParameters -UseSystemAssignedIdentity } | Should -Throw -ExpectedMessage 'Please provide input to the LocalContentPath parameter to use the UseSystemAssignedIdentity flag.'
 
                         $basePolicyParameters.Remove('ManagedIdentityResourceId')
+                        $basePolicyParameters.Remove('LocalContentPath')
+                    }
+
+                    It 'Should throw an error that both ManagedIdentityResourceId and UseSystemAssignedIdentity are provided' {
+                        $basePolicyParameters['ManagedIdentityResourceId'] = 'myManagedIdentity'
+                        $basePolicyParameters['UseSystemAssignedIdentity'] = $true
+                        $basePolicyParameters['LocalContentPath'] = $filePath
+
+                        { New-GuestConfigurationPolicy @basePolicyParameters } | Should -Throw -ExpectedMessage 'The ManagedIdentityResourceId parameter and UseSystemAssignedIdentity flag cannot be provided together.'
+
+                        $basePolicyParameters.Remove('ManagedIdentityResourceId')
+                        $basePolicyParameters.Remove('UseSystemAssignedIdentity')
+                        $basePolicyParameters.Remove('LocalContentPath')
+                    }
+
+                    It 'Should throw an error when LocalContentPath is provided but neither of the identity parameters are provided' {
+                        $basePolicyParameters['LocalContentPath'] = $filePath
+
+                        { New-GuestConfigurationPolicy @basePolicyParameters } | Should -Throw -ExpectedMessage 'LocalContentPath was provided, but no identity parameters were specified. Please include either the UseSystemAssignedIdentity or ManagedIdentityResourceId with LocalContentPath.'
+
                         $basePolicyParameters.Remove('LocalContentPath')
                     }
                 }


### PR DESCRIPTION
Added code for including system assigned identity as an alternative to user assigned identity for downloading custom policy packages.
Included new test cases and modified some test cases to reflect the changes in error messages.