### PR TITLE
Support more Linux OS and latest PowerShell

### DIFF
--- a/source/Private/Get-MofResouceDependencies.ps1
+++ b/source/Private/Get-MofResouceDependencies.ps1
@@ -9,33 +9,83 @@ function Get-MofResouceDependencies
         $MofFilePath
     )
 
-    $MofFilePath = Resolve-RelativePath -Path $MofFilePath
+    $platform = Get-OSPlatform
 
-    $resourceDependencies = @()
-    $reservedResourceNames = @('OMI_ConfigurationDocument')
-    $mofInstances = [Microsoft.PowerShell.DesiredStateConfiguration.Internal.DscClassCache]::ImportInstances($mofFilePath, 4)
-
-    foreach ($mofInstance in $mofInstances)
+    $scriptBlock =
     {
-        if ($reservedResourceNames -inotcontains $mofInstance.CimClass.CimClassName -and $mofInstance.CimInstanceProperties.Name -icontains 'ModuleName')
+        param
+        (
+            [Parameter(Mandatory = $true)]
+            [string] $MofFilePathString
+        )
+
+        $mofFilePath = [System.IO.FileInfo] $MofFilePathString
+        $mofFilePath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($mofFilePath)
+
+        $resourceDependencies = @()
+        $reservedResourceNames = @('OMI_ConfigurationDocument')
+        $mofInstances = [Microsoft.PowerShell.DesiredStateConfiguration.Internal.DscClassCache]::ImportInstances($mofFilePath, 4)
+
+        foreach ($mofInstance in $mofInstances)
         {
-            $instanceName = ""
-
-            if ($mofInstance.CimInstanceProperties.Name -icontains 'Name')
+            if ($reservedResourceNames -inotcontains $mofInstance.CimClass.CimClassName -and $mofInstance.CimInstanceProperties.Name -icontains 'ModuleName')
             {
-                $instanceName = $mofInstance.CimInstanceProperties['Name'].Value
-            }
+                $instanceName = ""
 
-            Write-Verbose -Message "Found resource dependency in mof with instance name '$instanceName' and resource name '$($mofInstance.CimClass.CimClassName)' from module '$($mofInstance.ModuleName)' with version '$($mofInstance.ModuleVersion)'."
-            $resourceDependencies += @{
-                ResourceInstanceName = $instanceName
-                ResourceName = $mofInstance.CimClass.CimClassName
-                ModuleName = $mofInstance.ModuleName
-                ModuleVersion = $mofInstance.ModuleVersion
+                if ($mofInstance.CimInstanceProperties.Name -icontains 'Name')
+                {
+                    $instanceName = $mofInstance.CimInstanceProperties['Name'].Value
+                }
+
+                Write-Verbose -Message "Found resource dependency in mof with instance name '$instanceName' and resource name '$($mofInstance.CimClass.CimClassName)' from module '$($mofInstance.ModuleName)' with version '$($mofInstance.ModuleVersion)'."
+                $resourceDependencies += @{
+                    ResourceInstanceName = $instanceName
+                    ResourceName = $mofInstance.CimClass.CimClassName
+                    ModuleName = $mofInstance.ModuleName
+                    ModuleVersion = $mofInstance.ModuleVersion
+                }
             }
         }
+
+        Write-Verbose -Message "Found $($resourceDependencies.Count) resource dependencies in the mof."
+        return $resourceDependencies
     }
 
-    Write-Verbose -Message "Found $($resourceDependencies.Count) resource dependencies in the mof."
-    return $resourceDependencies
+    if ($platform -ieq 'Windows')
+    {
+        # Execute logic in the current session
+        $resourceDependencies = @(& $scriptBlock $MofFilePath.FullName)
+        return [Hashtable[]] $resourceDependencies
+    }
+    else
+    {
+        $workerInstallPath = Get-GCWorkerRootPath
+        $binFolderDestinationPath = Join-Path -Path $workerInstallPath -ChildPath 'GC'
+
+        # Temporarily modify LD_LIBRARY_PATH to ensure the libmi.so library can be found
+        Write-Verbose -Message "Setting LD_LIBRARY_PATH to include: $binFolderDestinationPath"
+        $originalLdLibraryPath = $env:LD_LIBRARY_PATH
+        if ($originalLdLibraryPath)
+        {
+            $env:LD_LIBRARY_PATH = "$originalLdLibraryPath`:$binFolderDestinationPath"
+        }
+        else
+        {
+            $env:LD_LIBRARY_PATH = $binFolderDestinationPath
+        }
+
+        try
+        {
+            # Execute MOF processing in a separate PowerShell session because the ImportInstances method requires the
+            # libmi.so library to be available, and LD_LIBRARY_PATH must be set before the PowerShell process starts for
+            # the dynamic linker to find the library during process initialization.
+            $job = Start-Job -ScriptBlock $scriptBlock -ArgumentList $MofFilePath.FullName
+            $resourceDependencies = @(Receive-Job -Job $job -Wait -AutoRemoveJob)
+            return [Hashtable[]] $resourceDependencies
+        }
+        finally
+        {
+            $env:LD_LIBRARY_PATH = $originalLdLibraryPath
+        }
+    }
 }

--- a/source/Public/New-GuestConfigurationPackage.ps1
+++ b/source/Public/New-GuestConfigurationPackage.ps1
@@ -148,6 +148,13 @@ function New-GuestConfigurationPackage
     }
 
     # Validate dependencies
+    $platform = Get-OSPlatform
+    if ($platform -ine 'Windows')
+    {
+        # Install the Guest Configuration worker on Linux so that we can access the libmi.so library
+        Install-GCWorker
+    }
+
     $resourceDependencies = @( Get-MofResouceDependencies -MofFilePath $Configuration )
 
     if ($resourceDependencies.Count -le 0)


### PR DESCRIPTION
Machine configuration authoring on Linux is limited to Ubuntu 20 and PowerShell 7.2.4. Customers using newer versions see this error:

```
MethodInvocationException: Exception calling "ImportInstances" with "2" argument(s): "Unable to load shared library 'libmi' or one of its dependencies.
```

With this fix, we are able to support the latest Ubuntu, the latest Powershell, and other distros beyond Ubuntu like RedHat.

There are no functional changes for Windows. For Linux, we now,

1. Install (unzip) the GC worker when the New-GuestConfigurationPackage cmdlet is invoked. This is required because we need access to the libmi.so library which is included with the GC worker. The libmi.so library is required for MOF validation.
2. Temporarily and safely set the LD_LIBRARY_PATH environment variable to include libmi.so.
3. Create a separate, temporary, PowerShell process for MOF processing. This is required because LD_LIBRARY_PATH must be set before the process starts for the dynamic linker to find libmi.so during process initialization.