### PR TITLE
Fix unit test failures

### DIFF
--- a/tests/Public/Get-GuestConfigurationPackageComplianceStatus.Tests.ps1
+++ b/tests/Public/Get-GuestConfigurationPackageComplianceStatus.Tests.ps1
@@ -22,7 +22,7 @@ Describe 'Get-GuestConfigurationPackageComplianceStatus' {
         $script:testOutputPath = Join-Path -Path $TestDrive -ChildPath 'output'
 
         $script:originalPSModulePath = $env:PSModulePath
-        $env:PSModulePath = $env:PSModulePath + ";" + $testModulesFolderPath
+        $env:PSModulePath = $env:PSModulePath + [System.IO.Path]::PathSeparator + $testModulesFolderPath
     }
 
     AfterAll {

--- a/tests/Public/New-GuestConfigurationPackage.Tests.ps1
+++ b/tests/Public/New-GuestConfigurationPackage.Tests.ps1
@@ -22,7 +22,7 @@ Describe 'New-GuestConfigurationPackage' {
         $script:testOutputPath = Join-Path -Path $TestDrive -ChildPath 'output'
 
         $script:originalPSModulePath = $env:PSModulePath
-        $env:PSModulePath = $env:PSModulePath + ";" + $testModulesFolderPath
+        $env:PSModulePath = $env:PSModulePath + [System.IO.Path]::PathSeparator + $testModulesFolderPath
     }
 
     AfterAll {

--- a/tests/Public/New-GuestConfigurationPolicy.Tests.ps1
+++ b/tests/Public/New-GuestConfigurationPolicy.Tests.ps1
@@ -684,12 +684,6 @@ Describe 'New-GuestConfigurationPolicy' {
 
                         $result.PolicyId | Should -Not -BeNullOrEmpty
                         $result.PolicyId.GetType().Name | Should -Be 'Guid'
-
-                        $fileContent = Get-Content -Path $result.Path -Raw
-                        $fileContentJson = $fileContent | ConvertFrom-Json
-
-                        $imageConditionList = $fileContentJson.properties.policyRule.if.anyOf
-                        $imageConditionList | Should -BeNullOrEmpty
                     }
 
                     It 'Should have created the expected policy definition file' {

--- a/tests/Public/New-GuestConfigurationPolicy.Tests.ps1
+++ b/tests/Public/New-GuestConfigurationPolicy.Tests.ps1
@@ -684,6 +684,32 @@ Describe 'New-GuestConfigurationPolicy' {
 
                         $result.PolicyId | Should -Not -BeNullOrEmpty
                         $result.PolicyId.GetType().Name | Should -Be 'Guid'
+
+                        $fileContent = Get-Content -Path $result.Path -Raw
+                        $fileContentJson = $fileContent | ConvertFrom-Json
+
+                        if ($OptionalParameters.ContainsKey('Tag'))
+                        {
+                            $fileContentJson.properties.policyRule.if.allOf | Should -Not -BeNullOrEmpty
+                            $fileContentJson.properties.policyRule.if.allOf.Count | Should -Be 2
+                            $fileContentJson.properties.policyRule.if.allOf[0].anyOf | Should -Not -BeNullOrEmpty
+
+                            # Multiple tags: allOf[1].allOf contains the tag conditions
+                            # Single tag: allOf[1] is the tag condition directly
+                            if ($OptionalParameters['Tag'].Keys.Count -gt 1)
+                            {
+                                $fileContentJson.properties.policyRule.if.allOf[1].allOf | Should -Not -BeNullOrEmpty
+                            }
+                            else
+                            {
+                                $fileContentJson.properties.policyRule.if.allOf[1].field | Should -Not -BeNullOrEmpty
+                                $fileContentJson.properties.policyRule.if.allOf[1].equals | Should -Not -BeNullOrEmpty
+                            }
+                        }
+                        else
+                        {
+                            $fileContentJson.properties.policyRule.if.anyOf | Should -Not -BeNullOrEmpty
+                        }
                     }
 
                     It 'Should have created the expected policy definition file' {

--- a/tests/assets/TestModules/TestModule/TestModule.psd1
+++ b/tests/assets/TestModules/TestModule/TestModule.psd1
@@ -63,9 +63,6 @@
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
     FunctionsToExport = @()
 
-    # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
-    CmdletsToExport = @()
-
     # Variables to export from this module
     VariablesToExport = '*'
 


### PR DESCRIPTION
Fixing issues that are causing unit test failures.

* Fixed how the PSModulePath is being updated. On Linux, we need to use colon. Semicolon will not work. I'm using [System.IO.Path]::PathSeparator to be platform agnostic.
* Removed the CmdletsToExport property from TestModule.psd1 as it was causing issues loading the module. According to [docs](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_module_manifests?view=powershell-7.5#cmdletstoexport), "with CmdletsToExport set as an empty array, when you import this module no cmdlets the root module or any nested modules export are available." With this setting removed or commented, "all cmdlets in the root module and any nested modules are exported."
* In New-GuestConfigurationPolicy.Tests.ps1, we have an assertion that doesn't make sense. We're checking if the properties.policyRule.if.anyOf key in a policy definition is null or empty but that should not be possible. There is a case where hybrid machines are excluded but that case is covered in a different test case. I'm removing this assertion because it's causing unit test failures.