### PR TITLE
Adds Support for new style Packages and adds new -parametersOnly mode

### DIFF
--- a/source/Private/Invoke-GuestConfigurationPackage.ps1
+++ b/source/Private/Invoke-GuestConfigurationPackage.ps1
@@ -15,7 +15,11 @@ function Invoke-GuestConfigurationPackage
 
         [Parameter()]
         [Switch]
-        $Apply
+        $Apply,
+
+        [Parameter()]
+        [Switch]
+        $ParametersOnly
     )
 
     $os = Get-OSPlatform
@@ -259,7 +263,7 @@ function Invoke-GuestConfigurationPackage
     # Update package configuration parameters
     if ($null -ne $Parameter -and $Parameter.Count -gt 0)
     {
-        Set-GuestConfigurationPackageParameters -Path $mofFilePath -Parameter $Parameter
+        Set-GuestConfigurationPackageParameters -Path $mofFilePath -Parameter $Parameter -ParametersOnly:$ParametersOnly
     }
 
     # Publish the package via GC worker

--- a/source/Public/Get-GuestConfigurationPackageComplianceStatus.ps1
+++ b/source/Public/Get-GuestConfigurationPackageComplianceStatus.ps1
@@ -96,7 +96,10 @@ function Get-GuestConfigurationPackageComplianceStatus
 
         [Parameter()]
         [Hashtable[]]
-        $Parameter = @()
+        $Parameter = @(),
+
+        [Switch]
+        $ParametersOnly
     )
 
     $invokeParameters = @{
@@ -107,6 +110,13 @@ function Get-GuestConfigurationPackageComplianceStatus
     {
         $invokeParameters['Parameter'] = $Parameter
     }
+
+        
+    if($PSBoundParameters.ContainsKey('ParametersOnly'))
+    {
+        $invokeParameters['ParametersOnly'] = $ParametersOnly
+    }
+
 
     $result = Invoke-GuestConfigurationPackage @invokeParameters
 


### PR DESCRIPTION
Makes minor adjustments so that the module can handle items which do not use `[xModule]` syntax.  

Adds new -parametersOnly switch to `Get-GuestConfigurationPackageComplianceStatus`, which will prune unspecified settings from the `.mof` file, allowing for a more selective assignment compliance experience.

## Sample Usage 

In this example below, the package contains 300 settings in its `.mof` file. 

Our parameters payload for the assignment contains 275 settings.  When using the new `parametersOnly` mode, we would expect that the `.mof` file contains only 275 items (actually 276, accounting for the additional OMI_ConfigurationDocument field)

```
#private helper function which converts GCRP Style Parameters to module formatted hashtables

function ConvertTo-GCParamFormat {
    param (
        [Parameter(Mandatory=$true)]
        [array]$InputObject,
        $moduleName = 'GuestConfiguration'
    )

    $gcParams = @()
    foreach ($item in $InputObject) {   
        $paramObj = @{
            ResourceType            = $moduleName
            ResourceId              = $item.name.Split(';')[0]
            ResourcePropertyName    = $item.name.Split(';')[1]
            ResourcePropertyValue   = $item.value
        }
        $gcParams += $paramObj
    }
    return $gcParams
}


$gcParams =ConvertTo-GCParamFormat -InputObject $parms.settings -moduleName " " 

Compress-Archive -Path .\* -DestinationPath .\CISLinuxSecurityBaseline.zip -Force -Verbose
"about to invoke Get-GuestConfigurationPackageComplianceStatus"
Get-GuestConfigurationPackageComplianceStatus -path .\CISLinuxSecurityBaseline.zip  -Parameter $gcParams 

Get-content $expectedMofPath | ConvertFrom-Mof | measure-object -sum

Sum: 276
```