### PR TITLE
Adding New Parameter EnableAutoRemediation for Set Policies

### DIFF
--- a/source/Private/New-GuestConfigurationPolicyActionSection.ps1
+++ b/source/Private/New-GuestConfigurationPolicyActionSection.ps1
@@ -46,7 +46,7 @@ function New-GuestConfigurationPolicyActionSection
         $ExcludeArcMachines,
 
         [Parameter()]
-        [Switch]
+        [System.Boolean]
         $EnableAutoRemediation
     )
 
@@ -104,6 +104,7 @@ function New-GuestConfigurationPolicyActionSection
         }
     }
 
+    # Auto-enable for Set policies (not Audit)
     if ($EnableAutoRemediation)
     {
         $complianceCondition = $actionSection.details.existenceCondition

--- a/source/Private/New-GuestConfigurationPolicyActionSection.ps1
+++ b/source/Private/New-GuestConfigurationPolicyActionSection.ps1
@@ -43,7 +43,11 @@ function New-GuestConfigurationPolicyActionSection
 
         [Parameter()]
         [Switch]
-        $ExcludeArcMachines
+        $ExcludeArcMachines,
+
+        [Parameter()]
+        [Switch]
+        $EnableAutoRemediation
     )
 
     if ($AssignmentType -ieq 'Audit')
@@ -97,6 +101,32 @@ function New-GuestConfigurationPolicyActionSection
                 $complianceCondition,
                 $parameterCondition
             )
+        }
+    }
+
+    if ($EnableAutoRemediation)
+    {
+        $complianceCondition = $actionSection.details.existenceCondition
+
+        $enableAutoRemediationCondition = [Ordered]@{
+            value = "[parameters('EnableAutoRemediation')]"
+            in = @('true', 'false')
+        }
+
+        if ($complianceCondition.allOf)
+        {
+            # Already has allOf array (e.g., when there are parameters)
+            $actionSection.details.existenceCondition.allOf += $enableAutoRemediationCondition
+        }
+        else
+        {
+            # Simple existenceCondition, wrap it in allOf
+            $actionSection.details.existenceCondition = [Ordered]@{
+                allOf = @(
+                    $complianceCondition,
+                    $enableAutoRemediationCondition
+                )
+            }
         }
     }
 

--- a/source/Private/New-GuestConfigurationPolicyContent.ps1
+++ b/source/Private/New-GuestConfigurationPolicyContent.ps1
@@ -68,7 +68,7 @@ function New-GuestConfigurationPolicyContent
         $ExcludeArcMachines,
 
         [Parameter()]
-        [Switch]
+        [System.Boolean]
         $EnableAutoRemediation
     )
 

--- a/source/Private/New-GuestConfigurationPolicyContent.ps1
+++ b/source/Private/New-GuestConfigurationPolicyContent.ps1
@@ -65,7 +65,11 @@ function New-GuestConfigurationPolicyContent
 
         [Parameter()]
         [Switch]
-        $ExcludeArcMachines
+        $ExcludeArcMachines,
+
+        [Parameter()]
+        [Switch]
+        $EnableAutoRemediation
     )
 
     $metadataSectionParameters = @{
@@ -77,6 +81,8 @@ function New-GuestConfigurationPolicyContent
         ContentUri = $ContentUri
         ContentHash = $ContentHash
         Parameter = $Parameter
+        EnableAutoRemediation = $EnableAutoRemediation
+        AssignmentType = $AssignmentType
     }
 
     if (-not [string]::IsNullOrWhiteSpace($ManagedIdentityResourceId))
@@ -86,7 +92,7 @@ function New-GuestConfigurationPolicyContent
 
     $metadataSection = New-GuestConfigurationPolicyMetadataSection @metadataSectionParameters
 
-    $parametersSection = New-GuestConfigurationPolicyParametersSection -Parameter $Parameter -ExcludeArcMachines:$ExcludeArcMachines
+    $parametersSection = New-GuestConfigurationPolicyParametersSection -Parameter $Parameter -ExcludeArcMachines:$ExcludeArcMachines -EnableAutoRemediation:$EnableAutoRemediation
 
     $conditionsSection = New-GuestConfigurationPolicyConditionsSection -Platform $Platform -Tag $Tag -IncludeVMSS $IncludeVMSS -ExcludeArcMachines:$ExcludeArcMachines
 
@@ -98,6 +104,7 @@ function New-GuestConfigurationPolicyContent
         AssignmentType = $AssignmentType
         Parameter = $Parameter
         IncludeVMSS = $IncludeVMSS
+        EnableAutoRemediation = $EnableAutoRemediation
     }
 
     if (-not [string]::IsNullOrWhiteSpace($ManagedIdentityResourceId))

--- a/source/Private/New-GuestConfigurationPolicyMetadataSection.ps1
+++ b/source/Private/New-GuestConfigurationPolicyMetadataSection.ps1
@@ -74,7 +74,7 @@ function New-GuestConfigurationPolicyMetadataSection
     # Add assignmentType if EnableAutoRemediation is used
     if ($EnableAutoRemediation)
     {
-        $propertiesSection.metadata.guestConfiguration.assignmentType = "[if(equals(parameters('EnableAutoRemediation'),'true'),'$AssignmentType','Audit')]"
+        $propertiesSection.metadata.guestConfiguration.assignmentType = "[if(parameters('EnableAutoRemediation'),'$AssignmentType','Audit')]"
     }
     elseif ($null -ne $AssignmentType)
     {

--- a/source/Private/New-GuestConfigurationPolicyMetadataSection.ps1
+++ b/source/Private/New-GuestConfigurationPolicyMetadataSection.ps1
@@ -43,7 +43,16 @@ function New-GuestConfigurationPolicyMetadataSection
 
         [Parameter()]
         [Hashtable[]]
-        $Parameter
+        $Parameter,
+
+        [Parameter()]
+        [Switch]
+        $EnableAutoRemediation,
+
+        [Parameter()]
+        [ValidateSet('Audit', 'ApplyAndAutoCorrect', 'ApplyAndMonitor')]
+        [String]
+        $AssignmentType
     )
 
     $templateFileName = '1-Metadata.json'
@@ -60,6 +69,16 @@ function New-GuestConfigurationPolicyMetadataSection
         contentType = 'Custom'
         contentUri = $ContentUri
         contentHash = $ContentHash
+    }
+
+    # Add assignmentType if EnableAutoRemediation is used
+    if ($EnableAutoRemediation)
+    {
+        $propertiesSection.metadata.guestConfiguration.assignmentType = "[if(equals(parameters('EnableAutoRemediation'),'true'),'$AssignmentType','Audit')]"
+    }
+    elseif ($null -ne $AssignmentType)
+    {
+        $propertiesSection.metadata.guestConfiguration.assignmentType = $AssignmentType
     }
 
     if (-not [string]::IsNullOrWhiteSpace($ManagedIdentityResourceId))

--- a/source/Private/New-GuestConfigurationPolicyMetadataSection.ps1
+++ b/source/Private/New-GuestConfigurationPolicyMetadataSection.ps1
@@ -46,7 +46,7 @@ function New-GuestConfigurationPolicyMetadataSection
         $Parameter,
 
         [Parameter()]
-        [Switch]
+        [System.Boolean]
         $EnableAutoRemediation,
 
         [Parameter()]

--- a/source/Private/New-GuestConfigurationPolicyParametersSection.ps1
+++ b/source/Private/New-GuestConfigurationPolicyParametersSection.ps1
@@ -13,7 +13,7 @@ function New-GuestConfigurationPolicyParametersSection
         $ExcludeArcMachines,
 
         [Parameter()]
-        [Switch]
+        [System.Boolean]
         $EnableAutoRemediation
     )
 
@@ -28,7 +28,8 @@ function New-GuestConfigurationPolicyParametersSection
         }
     }
 
-    # Remove EnableAutoRemediation from template if not requested
+    # Auto-enable EnableAutoRemediation for Set policies (not Audit)
+    # Remove from template if this is an Audit policy
     if (-not $EnableAutoRemediation)
     {
         if ($parametersSection.parameters.EnableAutoRemediation)

--- a/source/Private/New-GuestConfigurationPolicyParametersSection.ps1
+++ b/source/Private/New-GuestConfigurationPolicyParametersSection.ps1
@@ -10,7 +10,11 @@ function New-GuestConfigurationPolicyParametersSection
 
         [Parameter()]
         [Switch]
-        $ExcludeArcMachines
+        $ExcludeArcMachines,
+
+        [Parameter()]
+        [Switch]
+        $EnableAutoRemediation
     )
 
     $templateFileName = '2-Parameters.json'
@@ -21,6 +25,15 @@ function New-GuestConfigurationPolicyParametersSection
         if ($parametersSection.parameters.IncludeArcMachines)
         {
             $parametersSection.parameters.Remove("IncludeArcMachines")
+        }
+    }
+
+    # Remove EnableAutoRemediation from template if not requested
+    if (-not $EnableAutoRemediation)
+    {
+        if ($parametersSection.parameters.EnableAutoRemediation)
+        {
+            $parametersSection.parameters.Remove("EnableAutoRemediation")
         }
     }
 

--- a/source/Public/New-GuestConfigurationPolicy.ps1
+++ b/source/Public/New-GuestConfigurationPolicy.ps1
@@ -245,11 +245,7 @@ function New-GuestConfigurationPolicy
 
         [Parameter()]
         [Switch]
-        $ExcludeArcMachines,
-
-        [Parameter()]
-        [Switch]
-        $EnableAutoRemediation
+        $ExcludeArcMachines
     )
 
     # Validate parameters
@@ -278,10 +274,8 @@ function New-GuestConfigurationPolicy
         throw "The ManagedIdentityResourceId parameter and UseSystemAssignedIdentity flag cannot be provided together."
     }
 
-    if ($EnableAutoRemediation -and $Mode -eq 'Audit')
-    {
-        throw "The EnableAutoRemediation parameter cannot be used with Audit mode. Please use ApplyAndAutoCorrect or ApplyAndMonitor mode."
-    }
+    # Automatically enable EnableAutoRemediation for Set policies (not Audit)
+    $EnableAutoRemediation = $Mode -ine 'Audit'
 
     if (-not [string]::IsNullOrWhiteSpace($ManagedIdentityResourceId) -and -not $UseSystemAssignedIdentity)
     {

--- a/source/Public/New-GuestConfigurationPolicy.ps1
+++ b/source/Public/New-GuestConfigurationPolicy.ps1
@@ -245,7 +245,11 @@ function New-GuestConfigurationPolicy
 
         [Parameter()]
         [Switch]
-        $ExcludeArcMachines
+        $ExcludeArcMachines,
+
+        [Parameter()]
+        [Switch]
+        $EnableAutoRemediation
     )
 
     # Validate parameters
@@ -273,6 +277,12 @@ function New-GuestConfigurationPolicy
     {
         throw "The ManagedIdentityResourceId parameter and UseSystemAssignedIdentity flag cannot be provided together."
     }
+
+    if ($EnableAutoRemediation -and $Mode -eq 'Audit')
+    {
+        throw "The EnableAutoRemediation parameter cannot be used with Audit mode. Please use ApplyAndAutoCorrect or ApplyAndMonitor mode."
+    }
+
     if (-not [string]::IsNullOrWhiteSpace($ManagedIdentityResourceId) -and -not $UseSystemAssignedIdentity)
     {
         if (-not $ExcludeArcMachines)
@@ -514,7 +524,7 @@ function New-GuestConfigurationPolicy
         $policyDefinitionContentParameters.ManagedIdentityResourceId = "system"
     }
 
-    $policyDefinitionContent = New-GuestConfigurationPolicyContent @policyDefinitionContentParameters -ExcludeArcMachines:$ExcludeArcMachines
+    $policyDefinitionContent = New-GuestConfigurationPolicyContent @policyDefinitionContentParameters -ExcludeArcMachines:$ExcludeArcMachines -EnableAutoRemediation:$EnableAutoRemediation
 
     # Convert definition hashtable to JSON
     $policyDefinitionContentJson = (ConvertTo-Json -InputObject $policyDefinitionContent -Depth 100).Replace('\u0027', "'")

--- a/source/templates/2-Parameters.json
+++ b/source/templates/2-Parameters.json
@@ -12,6 +12,18 @@
                 "false"
             ],
             "defaultValue": "false"
+        },
+        "EnableAutoRemediation": {
+            "type": "string",
+            "metadata": {
+                "displayName": "Enable Auto Remediation",
+                "description": "When true, the policy will automatically enforce the time zone configuration. When false, it will only audit"
+            },
+            "allowedValues": [
+                "true",
+                "false"
+            ],
+            "defaultValue": "false"
         }
     }
 }

--- a/source/templates/2-Parameters.json
+++ b/source/templates/2-Parameters.json
@@ -17,7 +17,7 @@
             "type": "string",
             "metadata": {
                 "displayName": "Enable Auto Remediation",
-                "description": "When true, the policy will automatically enforce the time zone configuration. When false, it will only audit"
+                "description": "When true, the policy will automatically enforce remediation. When false, it will only audit"
             },
             "allowedValues": [
                 "true",

--- a/tests/Public/New-GuestConfigurationPolicy.Tests.ps1
+++ b/tests/Public/New-GuestConfigurationPolicy.Tests.ps1
@@ -514,7 +514,7 @@ Describe 'New-GuestConfigurationPolicy' {
             )
         }
     ) {
-        Context '<platformString>' -ForEach @($Platform) -Skip:($_ -ieq 'Windows' -and $script:os -ine 'Windows') {
+            Context '<platformString>' -ForEach @($Platform) -Skip:($_ -ieq 'Windows' -and $script:os -ine 'Windows') {
             BeforeAll {
                 $platformString = $_
 
@@ -547,6 +547,7 @@ Describe 'New-GuestConfigurationPolicy' {
                     $baseAssertionParameters['ExpectedPlatform'] = $platformString
                 }
             }
+
 
             # Default Parameters
             Context 'Default parameters' {
@@ -871,6 +872,176 @@ Describe 'New-GuestConfigurationPolicy' {
                         { New-GuestConfigurationPolicy @basePolicyParameters } | Should -Throw -ExpectedMessage 'LocalContentPath was provided, but no identity parameters were specified. Please include either the UseSystemAssignedIdentity or ManagedIdentityResourceId with LocalContentPath.'
 
                         $basePolicyParameters.Remove('LocalContentPath')
+                    }
+                }
+
+                Context 'EnableAutoRemediation parameter' {
+                    AfterEach {
+                        # Clean up temp files to avoid file locks between tests
+                        Start-Sleep -Milliseconds 500  # Longer pause to allow file handles to release
+                        [System.GC]::Collect()
+                        [System.GC]::WaitForPendingFinalizers()
+                        Start-Sleep -Milliseconds 500
+
+                        $modulePath = Get-Module -Name 'GuestConfiguration' | Select-Object -ExpandProperty ModuleBase
+                        if ($modulePath) {
+                            $tempPath = Join-Path -Path $modulePath -ChildPath 'gcworker\temp'
+                            if (Test-Path -Path $tempPath) {
+                                Get-ChildItem -Path $tempPath -File -ErrorAction SilentlyContinue | ForEach-Object {
+                                    try {
+                                        Remove-Item -Path $_.FullName -Force -ErrorAction SilentlyContinue
+                                    } catch {
+                                        # Ignore file lock errors in cleanup
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    It 'Should throw an error when EnableAutoRemediation is used with Audit mode' {
+                        $testPolicyParameters = $basePolicyParameters.Clone()
+                        $testPolicyParameters['Mode'] = 'Audit'
+
+                        { New-GuestConfigurationPolicy @testPolicyParameters -EnableAutoRemediation } | Should -Throw -ExpectedMessage 'The EnableAutoRemediation parameter cannot be used with Audit mode. Please use ApplyAndAutoCorrect or ApplyAndMonitor mode.'
+                    }
+
+                    It 'Should include EnableAutoRemediation parameter when switch is used with ApplyAndAutoCorrect mode' {
+                        $testPolicyParameters = $basePolicyParameters.Clone()
+                        $testPolicyParameters['Mode'] = 'ApplyAndAutoCorrect'
+
+                        $result = New-GuestConfigurationPolicy @testPolicyParameters -EnableAutoRemediation
+
+                        $result | Should -Not -BeNull
+                        Test-Path -Path $result.Path | Should -BeTrue
+
+                        $fileContent = Get-Content -Path $result.Path -Raw
+                        $fileContentJson = $fileContent | ConvertFrom-Json
+
+                        # Verify EnableAutoRemediation parameter exists in parameters section
+                        $fileContentJson.properties.parameters.EnableAutoRemediation | Should -Not -BeNullOrEmpty
+                        $fileContentJson.properties.parameters.EnableAutoRemediation.type | Should -Be 'string'
+                        $fileContentJson.properties.parameters.EnableAutoRemediation.defaultValue | Should -Be 'false'
+                        $fileContentJson.properties.parameters.EnableAutoRemediation.allowedValues | Should -Be @('true', 'false')
+                        $fileContentJson.properties.parameters.EnableAutoRemediation.metadata | Should -Not -BeNullOrEmpty
+                        $fileContentJson.properties.parameters.EnableAutoRemediation.metadata.displayName | Should -Be 'Enable Auto Remediation'
+
+                        # Verify dynamic assignmentType in metadata.guestConfiguration
+                        $metadataAssignmentType = $fileContentJson.properties.metadata.guestConfiguration.assignmentType
+                        $metadataAssignmentType | Should -Not -BeNullOrEmpty
+                        $metadataAssignmentType | Should -Match "if\(equals\(parameters\('EnableAutoRemediation'\),'true'\),'ApplyAndAutoCorrect','Audit'\)"
+
+                        # Verify static assignmentType in deployment resources
+                        $deploymentTemplate = $fileContentJson.properties.policyRule.then.details.deployment.properties.template
+                        $resourceAssignmentType = $deploymentTemplate.resources[0].properties.guestConfiguration.assignmentType
+                        $resourceAssignmentType | Should -Be 'ApplyAndAutoCorrect'
+                        $resourceAssignmentType | Should -Not -Match "if\(equals\(parameters"
+
+                        # Verify EnableAutoRemediation check in existenceCondition
+                        $existenceCondition = $fileContentJson.properties.policyRule.then.details.existenceCondition
+                        $existenceCondition.allOf | Should -Not -BeNullOrEmpty
+                        $autoRemediationCondition = $existenceCondition.allOf | Where-Object { $_.value -eq "[parameters('EnableAutoRemediation')]" }
+                        $autoRemediationCondition | Should -Not -BeNullOrEmpty
+                        $autoRemediationCondition.in | Should -Be @('true', 'false')
+                    }
+
+                    It 'Should include EnableAutoRemediation parameter when switch is used with ApplyAndMonitor mode' {
+                        $testPolicyParameters = $basePolicyParameters.Clone()
+                        $testPolicyParameters['Mode'] = 'ApplyAndMonitor'
+
+                        $result = New-GuestConfigurationPolicy @testPolicyParameters -EnableAutoRemediation
+
+                        $result | Should -Not -BeNull
+                        Test-Path -Path $result.Path | Should -BeTrue
+
+                        $fileContent = Get-Content -Path $result.Path -Raw
+                        $fileContentJson = $fileContent | ConvertFrom-Json
+
+                        # Verify EnableAutoRemediation parameter exists
+                        $fileContentJson.properties.parameters.EnableAutoRemediation | Should -Not -BeNullOrEmpty
+
+                        # Verify dynamic assignmentType in metadata.guestConfiguration
+                        $metadataAssignmentType = $fileContentJson.properties.metadata.guestConfiguration.assignmentType
+                        $metadataAssignmentType | Should -Not -BeNullOrEmpty
+                        $metadataAssignmentType | Should -Match "if\(equals\(parameters\('EnableAutoRemediation'\),'true'\),'ApplyAndMonitor','Audit'\)"
+
+                        # Verify static assignmentType in deployment resources
+                        $deploymentTemplate = $fileContentJson.properties.policyRule.then.details.deployment.properties.template
+                        $resourceAssignmentType = $deploymentTemplate.resources[0].properties.guestConfiguration.assignmentType
+                        $resourceAssignmentType | Should -Be 'ApplyAndMonitor'
+
+                        # Verify EnableAutoRemediation check in existenceCondition
+                        $existenceCondition = $fileContentJson.properties.policyRule.then.details.existenceCondition
+                        $existenceCondition.allOf | Should -Not -BeNullOrEmpty
+                        $autoRemediationCondition = $existenceCondition.allOf | Where-Object { $_.value -eq "[parameters('EnableAutoRemediation')]" }
+                        $autoRemediationCondition | Should -Not -BeNullOrEmpty
+                    }
+
+                    It 'Should NOT include EnableAutoRemediation parameter when switch is not used' {
+                        $testPolicyParameters = $basePolicyParameters.Clone()
+                        $testPolicyParameters['Mode'] = 'ApplyAndAutoCorrect'
+
+                        $result = New-GuestConfigurationPolicy @testPolicyParameters
+
+                        $result | Should -Not -BeNull
+                        Test-Path -Path $result.Path | Should -BeTrue
+
+                        $fileContent = Get-Content -Path $result.Path -Raw
+                        $fileContentJson = $fileContent | ConvertFrom-Json
+
+                        # Verify EnableAutoRemediation parameter does NOT exist
+                        $fileContentJson.properties.parameters.EnableAutoRemediation | Should -BeNullOrEmpty
+
+                        # Verify static assignmentType in metadata (no dynamic expression)
+                        $metadataAssignmentType = $fileContentJson.properties.metadata.guestConfiguration.assignmentType
+                        $metadataAssignmentType | Should -Be 'ApplyAndAutoCorrect'
+                        $metadataAssignmentType | Should -Not -Match "if\(equals\(parameters"
+
+                        # Verify static assignmentType in deployment resources
+                        $deploymentTemplate = $fileContentJson.properties.policyRule.then.details.deployment.properties.template
+                        $resourceAssignmentType = $deploymentTemplate.resources[0].properties.guestConfiguration.assignmentType
+                        $resourceAssignmentType | Should -Be 'ApplyAndAutoCorrect'
+                        $resourceAssignmentType | Should -Not -Match "if\(equals\(parameters"
+
+                        # Verify NO EnableAutoRemediation check in existenceCondition
+                        $existenceCondition = $fileContentJson.properties.policyRule.then.details.existenceCondition
+                        if ($existenceCondition.allOf) {
+                            $autoRemediationCondition = $existenceCondition.allOf | Where-Object { $_.value -eq "[parameters('EnableAutoRemediation')]" }
+                            $autoRemediationCondition | Should -BeNullOrEmpty
+                        }
+                    }
+
+                    It 'Should use static assignmentType when EnableAutoRemediation is not used with ApplyAndMonitor' {
+                        $testPolicyParameters = $basePolicyParameters.Clone()
+                        $testPolicyParameters['Mode'] = 'ApplyAndMonitor'
+
+                        $result = New-GuestConfigurationPolicy @testPolicyParameters
+
+                        $result | Should -Not -BeNull
+                        Test-Path -Path $result.Path | Should -BeTrue
+
+                        $fileContent = Get-Content -Path $result.Path -Raw
+                        $fileContentJson = $fileContent | ConvertFrom-Json
+
+                        # Verify EnableAutoRemediation parameter does NOT exist
+                        $fileContentJson.properties.parameters.EnableAutoRemediation | Should -BeNullOrEmpty
+
+                        # Verify static assignmentType in metadata
+                        $metadataAssignmentType = $fileContentJson.properties.metadata.guestConfiguration.assignmentType
+                        $metadataAssignmentType | Should -Be 'ApplyAndMonitor'
+                        $metadataAssignmentType | Should -Not -Match "if\(equals\(parameters"
+
+                        # Verify static assignmentType in deployment resources
+                        $deploymentTemplate = $fileContentJson.properties.policyRule.then.details.deployment.properties.template
+                        $resourceAssignmentType = $deploymentTemplate.resources[0].properties.guestConfiguration.assignmentType
+                        $resourceAssignmentType | Should -Be 'ApplyAndMonitor'
+                        $resourceAssignmentType | Should -Not -Match "if\(equals\(parameters"
+
+                        # Verify NO EnableAutoRemediation check in existenceCondition
+                        $existenceCondition = $fileContentJson.properties.policyRule.then.details.existenceCondition
+                        if ($existenceCondition.allOf) {
+                            $autoRemediationCondition = $existenceCondition.allOf | Where-Object { $_.value -eq "[parameters('EnableAutoRemediation')]" }
+                            $autoRemediationCondition | Should -BeNullOrEmpty
+                        }
                     }
                 }
             }

--- a/tests/Public/New-GuestConfigurationPolicy.Tests.ps1
+++ b/tests/Public/New-GuestConfigurationPolicy.Tests.ps1
@@ -875,7 +875,7 @@ Describe 'New-GuestConfigurationPolicy' {
                     }
                 }
 
-                Context 'EnableAutoRemediation parameter' {
+                Context 'Automatic EnableAutoRemediation for Set policies' {
                     AfterEach {
                         # Clean up temp files to avoid file locks between tests
                         Start-Sleep -Milliseconds 500  # Longer pause to allow file handles to release
@@ -898,18 +898,40 @@ Describe 'New-GuestConfigurationPolicy' {
                         }
                     }
 
-                    It 'Should throw an error when EnableAutoRemediation is used with Audit mode' {
+                    It 'Should NOT include EnableAutoRemediation parameter for Audit mode' {
                         $testPolicyParameters = $basePolicyParameters.Clone()
                         $testPolicyParameters['Mode'] = 'Audit'
 
-                        { New-GuestConfigurationPolicy @testPolicyParameters -EnableAutoRemediation } | Should -Throw -ExpectedMessage 'The EnableAutoRemediation parameter cannot be used with Audit mode. Please use ApplyAndAutoCorrect or ApplyAndMonitor mode.'
+                        $result = New-GuestConfigurationPolicy @testPolicyParameters
+
+                        $result | Should -Not -BeNull
+                        Test-Path -Path $result.Path | Should -BeTrue
+
+                        $fileContent = Get-Content -Path $result.Path -Raw
+                        $fileContentJson = $fileContent | ConvertFrom-Json
+
+                        # Verify EnableAutoRemediation parameter does NOT exist for Audit mode
+                        $fileContentJson.properties.parameters.EnableAutoRemediation | Should -BeNullOrEmpty
+
+                        # Verify static assignmentType in metadata (no dynamic expression)
+                        $metadataAssignmentType = $fileContentJson.properties.metadata.guestConfiguration.assignmentType
+                        $metadataAssignmentType | Should -Be 'Audit'
+                        $metadataAssignmentType | Should -Not -Match "if\(parameters"
+
+                        # For Audit mode, this is AuditIfNotExists (no deployment section)
+                        # Verify NO EnableAutoRemediation check in existenceCondition
+                        $existenceCondition = $fileContentJson.properties.policyRule.then.details.existenceCondition
+                        if ($existenceCondition.allOf) {
+                            $autoRemediationCondition = $existenceCondition.allOf | Where-Object { $_.value -eq "[parameters('EnableAutoRemediation')]" }
+                            $autoRemediationCondition | Should -BeNullOrEmpty
+                        }
                     }
 
-                    It 'Should include EnableAutoRemediation parameter when switch is used with ApplyAndAutoCorrect mode' {
+                    It 'Should automatically include EnableAutoRemediation parameter for ApplyAndAutoCorrect mode' {
                         $testPolicyParameters = $basePolicyParameters.Clone()
                         $testPolicyParameters['Mode'] = 'ApplyAndAutoCorrect'
 
-                        $result = New-GuestConfigurationPolicy @testPolicyParameters -EnableAutoRemediation
+                        $result = New-GuestConfigurationPolicy @testPolicyParameters
 
                         $result | Should -Not -BeNull
                         Test-Path -Path $result.Path | Should -BeTrue
@@ -934,7 +956,7 @@ Describe 'New-GuestConfigurationPolicy' {
                         $deploymentTemplate = $fileContentJson.properties.policyRule.then.details.deployment.properties.template
                         $resourceAssignmentType = $deploymentTemplate.resources[0].properties.guestConfiguration.assignmentType
                         $resourceAssignmentType | Should -Be 'ApplyAndAutoCorrect'
-                        $resourceAssignmentType | Should -Not -Match "if\(equals\(parameters"
+                        $resourceAssignmentType | Should -Not -Match "if\(parameters"
 
                         # Verify EnableAutoRemediation check in existenceCondition
                         $existenceCondition = $fileContentJson.properties.policyRule.then.details.existenceCondition
@@ -944,11 +966,11 @@ Describe 'New-GuestConfigurationPolicy' {
                         $autoRemediationCondition.in | Should -Be @('true', 'false')
                     }
 
-                    It 'Should include EnableAutoRemediation parameter when switch is used with ApplyAndMonitor mode' {
+                    It 'Should automatically include EnableAutoRemediation parameter for ApplyAndMonitor mode' {
                         $testPolicyParameters = $basePolicyParameters.Clone()
                         $testPolicyParameters['Mode'] = 'ApplyAndMonitor'
 
-                        $result = New-GuestConfigurationPolicy @testPolicyParameters -EnableAutoRemediation
+                        $result = New-GuestConfigurationPolicy @testPolicyParameters
 
                         $result | Should -Not -BeNull
                         Test-Path -Path $result.Path | Should -BeTrue
@@ -958,6 +980,8 @@ Describe 'New-GuestConfigurationPolicy' {
 
                         # Verify EnableAutoRemediation parameter exists
                         $fileContentJson.properties.parameters.EnableAutoRemediation | Should -Not -BeNullOrEmpty
+                        $fileContentJson.properties.parameters.EnableAutoRemediation.type | Should -Be 'string'
+                        $fileContentJson.properties.parameters.EnableAutoRemediation.defaultValue | Should -Be 'false'
 
                         # Verify dynamic assignmentType in metadata.guestConfiguration
                         $metadataAssignmentType = $fileContentJson.properties.metadata.guestConfiguration.assignmentType
@@ -974,9 +998,10 @@ Describe 'New-GuestConfigurationPolicy' {
                         $existenceCondition.allOf | Should -Not -BeNullOrEmpty
                         $autoRemediationCondition = $existenceCondition.allOf | Where-Object { $_.value -eq "[parameters('EnableAutoRemediation')]" }
                         $autoRemediationCondition | Should -Not -BeNullOrEmpty
+                        $autoRemediationCondition.in | Should -Be @('true', 'false')
                     }
 
-                    It 'Should NOT include EnableAutoRemediation parameter when switch is not used' {
+                    It 'Should use dynamic assignmentType for ApplyAndAutoCorrect Set policies' {
                         $testPolicyParameters = $basePolicyParameters.Clone()
                         $testPolicyParameters['Mode'] = 'ApplyAndAutoCorrect'
 
@@ -988,29 +1013,18 @@ Describe 'New-GuestConfigurationPolicy' {
                         $fileContent = Get-Content -Path $result.Path -Raw
                         $fileContentJson = $fileContent | ConvertFrom-Json
 
-                        # Verify EnableAutoRemediation parameter does NOT exist
-                        $fileContentJson.properties.parameters.EnableAutoRemediation | Should -BeNullOrEmpty
-
-                        # Verify static assignmentType in metadata (no dynamic expression)
+                        # Verify dynamic assignmentType in metadata
                         $metadataAssignmentType = $fileContentJson.properties.metadata.guestConfiguration.assignmentType
-                        $metadataAssignmentType | Should -Be 'ApplyAndAutoCorrect'
-                        $metadataAssignmentType | Should -Not -Match "if\(equals\(parameters"
+                        $metadataAssignmentType | Should -Match "if\(parameters\('EnableAutoRemediation'\),'ApplyAndAutoCorrect','Audit'\)"
 
-                        # Verify static assignmentType in deployment resources
+                        # Verify static assignmentType in deployment (not dynamic)
                         $deploymentTemplate = $fileContentJson.properties.policyRule.then.details.deployment.properties.template
                         $resourceAssignmentType = $deploymentTemplate.resources[0].properties.guestConfiguration.assignmentType
                         $resourceAssignmentType | Should -Be 'ApplyAndAutoCorrect'
-                        $resourceAssignmentType | Should -Not -Match "if\(equals\(parameters"
-
-                        # Verify NO EnableAutoRemediation check in existenceCondition
-                        $existenceCondition = $fileContentJson.properties.policyRule.then.details.existenceCondition
-                        if ($existenceCondition.allOf) {
-                            $autoRemediationCondition = $existenceCondition.allOf | Where-Object { $_.value -eq "[parameters('EnableAutoRemediation')]" }
-                            $autoRemediationCondition | Should -BeNullOrEmpty
-                        }
+                        $resourceAssignmentType | Should -Not -Match "if\(parameters"
                     }
 
-                    It 'Should use static assignmentType when EnableAutoRemediation is not used with ApplyAndMonitor' {
+                    It 'Should use dynamic assignmentType for ApplyAndMonitor Set policies' {
                         $testPolicyParameters = $basePolicyParameters.Clone()
                         $testPolicyParameters['Mode'] = 'ApplyAndMonitor'
 
@@ -1022,26 +1036,15 @@ Describe 'New-GuestConfigurationPolicy' {
                         $fileContent = Get-Content -Path $result.Path -Raw
                         $fileContentJson = $fileContent | ConvertFrom-Json
 
-                        # Verify EnableAutoRemediation parameter does NOT exist
-                        $fileContentJson.properties.parameters.EnableAutoRemediation | Should -BeNullOrEmpty
-
-                        # Verify static assignmentType in metadata
+                        # Verify dynamic assignmentType in metadata
                         $metadataAssignmentType = $fileContentJson.properties.metadata.guestConfiguration.assignmentType
-                        $metadataAssignmentType | Should -Be 'ApplyAndMonitor'
-                        $metadataAssignmentType | Should -Not -Match "if\(equals\(parameters"
+                        $metadataAssignmentType | Should -Match "if\(parameters\('EnableAutoRemediation'\),'ApplyAndMonitor','Audit'\)"
 
-                        # Verify static assignmentType in deployment resources
+                        # Verify static assignmentType in deployment (not dynamic)
                         $deploymentTemplate = $fileContentJson.properties.policyRule.then.details.deployment.properties.template
                         $resourceAssignmentType = $deploymentTemplate.resources[0].properties.guestConfiguration.assignmentType
                         $resourceAssignmentType | Should -Be 'ApplyAndMonitor'
-                        $resourceAssignmentType | Should -Not -Match "if\(equals\(parameters"
-
-                        # Verify NO EnableAutoRemediation check in existenceCondition
-                        $existenceCondition = $fileContentJson.properties.policyRule.then.details.existenceCondition
-                        if ($existenceCondition.allOf) {
-                            $autoRemediationCondition = $existenceCondition.allOf | Where-Object { $_.value -eq "[parameters('EnableAutoRemediation')]" }
-                            $autoRemediationCondition | Should -BeNullOrEmpty
-                        }
+                        $resourceAssignmentType | Should -Not -Match "if\(parameters"
                     }
                 }
             }

--- a/tests/Public/New-GuestConfigurationPolicy.Tests.ps1
+++ b/tests/Public/New-GuestConfigurationPolicy.Tests.ps1
@@ -928,7 +928,7 @@ Describe 'New-GuestConfigurationPolicy' {
                         # Verify dynamic assignmentType in metadata.guestConfiguration
                         $metadataAssignmentType = $fileContentJson.properties.metadata.guestConfiguration.assignmentType
                         $metadataAssignmentType | Should -Not -BeNullOrEmpty
-                        $metadataAssignmentType | Should -Match "if\(equals\(parameters\('EnableAutoRemediation'\),'true'\),'ApplyAndAutoCorrect','Audit'\)"
+                        $metadataAssignmentType | Should -Match "if\(parameters\('EnableAutoRemediation'\),'ApplyAndAutoCorrect','Audit'\)"
 
                         # Verify static assignmentType in deployment resources
                         $deploymentTemplate = $fileContentJson.properties.policyRule.then.details.deployment.properties.template
@@ -962,7 +962,7 @@ Describe 'New-GuestConfigurationPolicy' {
                         # Verify dynamic assignmentType in metadata.guestConfiguration
                         $metadataAssignmentType = $fileContentJson.properties.metadata.guestConfiguration.assignmentType
                         $metadataAssignmentType | Should -Not -BeNullOrEmpty
-                        $metadataAssignmentType | Should -Match "if\(equals\(parameters\('EnableAutoRemediation'\),'true'\),'ApplyAndMonitor','Audit'\)"
+                        $metadataAssignmentType | Should -Match "if\(parameters\('EnableAutoRemediation'\),'ApplyAndMonitor','Audit'\)"
 
                         # Verify static assignmentType in deployment resources
                         $deploymentTemplate = $fileContentJson.properties.policyRule.then.details.deployment.properties.template


### PR DESCRIPTION
This PR includes changes to add a new parameter "EnableAutoRemediation". This will allow customers to opt for this setting when creating custom set policies. This new parameter will determine the AssignmentType dynamically. By default, the value will be "false". 

Changes in custom policy definition:

1.  "metadata": {

      "version": "3.1.0",
      "category": "Guest Configuration",
      "requiredProviders": [
        "Microsoft.GuestConfiguration"
      ],
      "guestConfiguration": {
        "name": "SetWindowsTimeZone",
        "version": "1.*",
        **"assignmentType": "[if(parameters('EnableAutoRemediation'),'ApplyAndAutoCorrect','Audit')]",**
        "configurationParameter": {
          "TimeZone": "[WindowsTimeZone]WindowsTimeZone1;TimeZone"
        }
      },

 2. "parameters": {
      **"EnableAutoRemediation": {**
        "type": "String",
        "metadata": {
          "displayName": "Enable Auto Remediation",
          "description": "When true, the policy will automatically enforce the time zone configuration. When false, it will only audit"
        },
        "allowedValues": [
          "true",
          "false"
        ],
        "defaultValue": "false"
      },

 3.  "existenceCondition": {
            "allOf": [
              {
                "field": "Microsoft.GuestConfiguration/guestConfigurationAssignments/parameterHash",
                "equals": "[base64(concat('[WindowsTimeZone]WindowsTimeZone1;TimeZone', '=', parameters('TimeZone')))]"
              },
              {
                "field": "Microsoft.GuestConfiguration/guestConfigurationAssignments/complianceStatus",
                "equals": "Compliant"
              },
              **{
                "value": "[parameters('EnableAutoRemediation')]",
                "in": [
                  "true",
                  "false"
                ]
              }**
            ]
          },